### PR TITLE
Add SQL DBA audit skill suite (sql-lint / sql-plan-audit / sql-schema-audit / sql-security)

### DIFF
--- a/sql-lint/.sqlfluff
+++ b/sql-lint/.sqlfluff
@@ -1,0 +1,24 @@
+; sqlfluff config tuned for sqlc-style query catalogs targeting SQLite / D1.
+; Run via `uvx sqlfluff lint --config skills/sql-lint/.sqlfluff <file>`.
+
+[sqlfluff]
+dialect = sqlite
+templater = raw
+exclude_rules =
+  AM04,   ; SELECT * — handled by catalog-lint with better context.
+  CP02,   ; Inconsistent capitalisation of identifiers — too noisy on quoted JSON refs.
+  L009,   ; Files must end with a single trailing newline — git enforces.
+
+[sqlfluff:rules:capitalisation.keywords]
+capitalisation_policy = upper
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = lower
+
+[sqlfluff:rules:layout.long_lines]
+max_line_length = 200
+
+[sqlfluff:rules:ambiguous.column_count]
+; Disabled: many of our queries SELECT specific columns whose count is
+; intentional; sqlfluff cannot tell that.
+disabled = true

--- a/sql-lint/SKILL.md
+++ b/sql-lint/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: sql-lint
+description: Static lint for sqlc-style SQL catalogs. Catches duplicate query names, missing semicolons, SELECT *, double-wildcard LIKE, and other cheap-but-easy-to-miss mistakes. Optional sqlfluff integration for full style coverage.
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [sql, sqlite, d1, dba, lint, sqlc]
+    related_skills: [sql-plan-audit, sql-schema-audit, sql-security]
+    engines: [sqlite, postgres, mysql]
+---
+
+# SQL Lint
+
+Use this when a project has a SQL catalog (`-- name: X :type` comments or any named-query convention) and wants to enforce basic hygiene without adopting a heavy SQL linter.
+
+## Two layers
+
+This skill ships **two** linters, with different cost / coverage trade-offs.
+
+### Layer 1: catalog-lint (built-in, zero deps)
+
+`scripts/catalog-lint.mjs` is a Node 20+ script with no dependencies. It catches:
+
+- **duplicate-name**: two queries with the same `-- name: X` header. Some codegens silently shadow; others break.
+- **missing-semicolon**: queries that omit the trailing `;`. sqlc rejects these at build time, but catalog-lint surfaces them in fmt-time.
+- **empty-body**: header with no SQL body.
+- **malformed-name**: `-- name:` line that doesn't match `name: X :type`.
+- **select-star**: `SELECT *` (always over-fetch).
+- **double-wildcard-like**: `LIKE '%...%'` (full-table scan risk).
+
+Run:
+
+```bash
+node scripts/catalog-lint.mjs your-project/db/queries.sql
+```
+
+Exits 0 on clean / 1 on findings. Output is `file:line: [rule] message`, parseable by editor diagnostic gutters.
+
+### Layer 2: sqlfluff (optional, opt-in)
+
+For full style coverage — keyword case, indentation, alias names, etc. — use `sqlfluff`. The skill ships `.sqlfluff` tuned for SQLite/D1 + sqlc catalogs:
+
+```bash
+uvx sqlfluff lint --config .sqlfluff your-project/db/queries.sql
+```
+
+`uvx` (from astral.sh/uv) runs sqlfluff in an ephemeral venv; nothing is installed permanently. If `uv` is missing, fall back to `pip install sqlfluff` or `pipx install sqlfluff`.
+
+The shipped config disables a few sqlfluff rules:
+
+- `AM04` (SELECT *) is handled by catalog-lint with better context.
+- `CP02` (column case) is too noisy on JSON path references like `obj.field_name`.
+- `L009` (trailing newline) is enforced by git.
+
+## When to invoke
+
+- Every commit that touches the query catalog (pre-commit / pre-push hook).
+- Once per migration milestone, run sqlfluff for the full style pass.
+
+## Inline SQL in host code
+
+This skill does **not** police inline SQL in MoonBit / Rust / Go / etc. — `ast-grep` is the right tool there, but it requires per-language tree-sitter support. For host languages without a tree-sitter grammar (e.g. MoonBit), a text-grep baseline file (`.linters/inline-sql-baseline.json`) works: count `.prepare(` occurrences per file and refuse increases.
+
+The companion `sql-security` skill documents the same approach for SQL injection.
+
+## CI integration
+
+```just
+sql-lint:
+    node scripts/catalog-lint.mjs db/queries.sql
+```
+
+For full sqlfluff in CI, run a separate `sql-lint-style` step so the cheap catalog-lint can fail fast.
+
+## Engine extensibility
+
+`catalog-lint.mjs` is engine-agnostic — the rules look at SQL comments, semicolons, and basic patterns. Adapt to MySQL / Postgres by changing the sqlfluff `dialect = sqlite` line in `.sqlfluff`.
+
+## Requirements
+
+- Node 20 or newer for `scripts/catalog-lint.mjs`.
+- (Optional) `uv` / `pipx` / `pip` for sqlfluff.
+
+## Files
+
+- `scripts/catalog-lint.mjs` — zero-dep catalog linter.
+- `.sqlfluff` — opt-in sqlfluff config (SQLite dialect; change `dialect = ...` for other engines).

--- a/sql-lint/scripts/catalog-lint.mjs
+++ b/sql-lint/scripts/catalog-lint.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Minimal sanity lint for sqlc-style query catalogs.
+//
+// Catches the cheap-but-easy-to-miss mistakes that sqlc itself does not flag:
+//   - duplicate `-- name: X :type` (the second one silently shadows in some
+//     codegens, broken in others)
+//   - missing trailing `;` (sqlc requires it)
+//   - `SELECT *` (always over-fetch; spell out the columns instead)
+//   - bare `LIKE '%foo%'` (full-table scan; only flagged when no neighbouring
+//     index condition is obvious)
+//   - empty body between two `-- name:` markers
+//   - `-- name:` line that does not match the `name: X :type` shape
+//
+// Heavier shape / style checking belongs in sqlfluff (see SKILL.md). This
+// script has zero dependencies so it works in any CI without extra tooling.
+
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+  const args = { files: [], rules: "default" };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--rules") args.rules = argv[++i];
+    else if (k === "--help" || k === "-h") {
+      console.error(
+        "catalog-lint.mjs [--rules default|strict] <file> [<file> ...]",
+      );
+      process.exit(0);
+    } else args.files.push(k);
+  }
+  if (args.files.length === 0) {
+    console.error("at least one query file is required");
+    process.exit(2);
+  }
+  return args;
+}
+
+function lintFile(path, source, rules) {
+  const findings = [];
+  const lines = source.split("\n");
+  const names = new Map(); // name -> first line number
+
+  let current = null;
+  let currentStart = 0;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (line.startsWith("-- name:")) {
+      // Flush previous query.
+      if (current) {
+        flushQuery(path, current, currentStart, findings);
+      }
+      const match = line.match(/^--\s*name:\s*(\S+)\s*:(\S+)\s*$/);
+      if (!match) {
+        findings.push({
+          path, line: i + 1, rule: "malformed-name",
+          message: `malformed -- name: line: ${JSON.stringify(line)}`,
+        });
+        current = null;
+        continue;
+      }
+      const name = match[1];
+      if (names.has(name)) {
+        findings.push({
+          path, line: i + 1, rule: "duplicate-name",
+          message: `duplicate query name '${name}' (also at line ${names.get(name)})`,
+        });
+      } else {
+        names.set(name, i + 1);
+      }
+      current = { name, type: match[2], body: [], headerLine: i + 1 };
+      currentStart = i + 1;
+      continue;
+    }
+    if (current) current.body.push(line);
+  }
+  if (current) flushQuery(path, current, currentStart, findings);
+
+  if (rules === "strict") {
+    // Add strict-only checks here in future.
+  }
+  return findings;
+}
+
+function flushQuery(path, query, start, findings) {
+  const body = query.body.join("\n").trim();
+  if (body.length === 0) {
+    findings.push({
+      path, line: query.headerLine, rule: "empty-body",
+      message: `query '${query.name}' has no SQL body`,
+    });
+    return;
+  }
+  if (!body.endsWith(";")) {
+    findings.push({
+      path, line: query.headerLine, rule: "missing-semicolon",
+      message: `query '${query.name}' does not end with ';'`,
+    });
+  }
+  // Comments stripped before pattern checks.
+  const stripped = body
+    .split("\n")
+    .map((l) => l.replace(/--.*$/, ""))
+    .join("\n");
+  if (/\bSELECT\s+\*/i.test(stripped)) {
+    findings.push({
+      path, line: query.headerLine, rule: "select-star",
+      message: `query '${query.name}' uses SELECT * (spell out columns)`,
+    });
+  }
+  // LIKE '%...%' is fine on FTS / small tables; we only flag the unanchored
+  // double-wildcard variant. Single-anchor (`LIKE 'foo%'`) can use a B-tree.
+  if (/LIKE\s+['"]%[^'"]*%['"]/i.test(stripped)) {
+    findings.push({
+      path, line: query.headerLine, rule: "double-wildcard-like",
+      message: `query '${query.name}' uses LIKE '%...%' (full scan risk)`,
+    });
+  }
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let findings = [];
+  for (const f of args.files) {
+    const abs = resolve(f);
+    const text = readFileSync(abs, "utf8");
+    findings = findings.concat(lintFile(abs, text, args.rules));
+  }
+  if (findings.length === 0) {
+    console.log("sql catalog lint: ok");
+    process.exit(0);
+  }
+  for (const f of findings) {
+    console.log(`${f.path}:${f.line}: [${f.rule}] ${f.message}`);
+  }
+  console.error(`sql catalog lint: ${findings.length} findings`);
+  process.exit(1);
+}
+
+main();

--- a/sql-plan-audit/SKILL.md
+++ b/sql-plan-audit/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: sql-plan-audit
+description: Run EXPLAIN QUERY PLAN against every query in a sqlc-style catalog and diff the plans against a baseline. Detects new full-table SCANs and TEMP B-TREE sort scans introduced by PRs. SQLite/D1-only today; engine extension noted below.
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [sql, sqlite, d1, dba, performance, sqlc]
+    related_skills: [sql-lint, sql-schema-audit, sql-security]
+    engines: [sqlite]
+---
+
+# SQL Plan Audit
+
+Use this when a project has a sqlc-style query catalog (or any file with `-- name: X :type` markers) and wants to keep query plans visible in code review.
+
+## Why
+
+`sqlc` enforces SQL syntax at codegen, but it doesn't watch the execution plan. A column rename, a removed index, or a small WHERE-clause addition can flip a query from `SEARCH USING INDEX` to `SCAN TABLE` silently. On Cloudflare D1 / SQLite without `EXPLAIN ANALYZE`, the planner output is the only static signal. This skill freezes that output as a reviewable artifact.
+
+## When to invoke
+
+- Schema or query catalog changed in a PR.
+- A new index was added and you want to confirm queries pick it up.
+- Quarterly audit of an existing query catalog.
+
+## Workflow
+
+1. Identify the schema file and the query catalog file. Typical layout:
+   ```
+   <project>/db/schema.sql
+   <project>/db/queries.sql   (or db/sqlite/query.sql for sqlc projects)
+   ```
+2. Run the runner:
+   ```bash
+   node scripts/explain-runner.mjs \
+     --schema your-project/db/schema.sql \
+     --queries your-project/db/queries.sql \
+     --out your-project/.linters/query-plans.txt
+   ```
+3. Commit the output. The text format is line-stable across runs; diffs surface plan changes.
+4. To enforce in CI, regenerate to JSON and diff against a committed baseline:
+   ```bash
+   node scripts/explain-runner.mjs \
+     --schema your-project/db/schema.sql \
+     --queries your-project/db/queries.sql \
+     --baseline your-project/.linters/query-plans.json \
+     --format json --fail-on regress
+   ```
+5. When intentional regressions land (e.g. an index was retired on purpose), regenerate the baseline in the same PR.
+
+## What success and failure look like
+
+The runner is **deliberately silent** on success. Knowing where output lands matters when wiring it into CI:
+
+| Invocation | stdout | stderr | Exit |
+|---|---|---|---|
+| `--out <path>` (regen) | nothing | only Node's `node:sqlite` experimental warning | 0 |
+| no `--out` (regen) | full text/JSON report | only the experimental warning | 0 |
+| `--baseline <path> --fail-on regress` (CI check), clean | full text/JSON report (or nothing if `--out` is set) | only the experimental warning | 0 |
+| `--baseline <path> --fail-on regress` (CI check), regression | full text/JSON report | **per-query regression detail** (before vs after plans) | 1 |
+| any path, internal error (e.g. schema fails to load) | nothing or partial | Node stack trace | 1 |
+
+Read this as: **stderr is where pass/fail diagnostics live**. In CI, capture stderr explicitly (`2>&1`, `2>artifact.log`, or separate streams) — piping only stdout to a parser will lose every regression message. If a regen run "prints nothing", check `$?` and `ls <out path>` to confirm; that is the documented happy-path.
+
+## How the runner handles placeholders
+
+`sqlc.arg('x')` and `sqlc.slice('x')` are rewritten to `NULL` before EXPLAIN runs. The plan does not depend on bind values, only on the SQL shape, so this is safe. `?` positional placeholders are left as-is — SQLite accepts them inside EXPLAIN.
+
+## Severity markers
+
+- `!` SCAN — full-table scan. Usually a missing index or a query intentionally touching every row.
+- `?` TEMP B-TREE — `USE TEMP B-TREE FOR ORDER BY / GROUP BY / DISTINCT`. Sort happens in memory because no index covers the ordering.
+- `  ` SEARCH — index hit. Normal.
+
+A plan with one SCAN on a small table (e.g. `users` with <1k rows) is often fine; the marker is a flag, not a verdict.
+
+## CI integration
+
+Add a step that runs the JSON variant and fails on regression. A typical `justfile`:
+
+```just
+sql-plan-audit:
+    node scripts/explain-runner.mjs \
+      --schema db/schema.sql \
+      --queries db/queries.sql \
+      --out .linters/query-plans.txt
+    node scripts/explain-runner.mjs \
+      --schema db/schema.sql \
+      --queries db/queries.sql \
+      --format json --out .linters/query-plans.json
+
+sql-plan-audit-check:
+    node scripts/explain-runner.mjs \
+      --schema db/schema.sql \
+      --queries db/queries.sql \
+      --baseline .linters/query-plans.json \
+      --format json --fail-on regress
+```
+
+Pre-push (pkfire / lefthook / pre-commit) is the right boundary — running this on every commit is slow and noisy.
+
+## Limitations
+
+- SQLite EXPLAIN does not report estimated row counts, so the runner cannot rank "bad SCAN of 10M rows" vs "fine SCAN of 50 rows". Combine with manual review.
+- FTS5 virtual tables show as `SCAN VIRTUAL TABLE`. Treated as info, not flagged.
+- Functions like `datetime('now')` are evaluated at plan time. Side effects (writes) are not run because the in-memory DB has the same schema but no rows.
+- Subqueries and CTEs may produce extra rows in the plan; the diff treats them stably.
+
+## Engine extensibility
+
+The runner is SQLite-specific. To support Postgres / MySQL: swap the `node:sqlite` driver and the EXPLAIN syntax; the parser, baseline diff, and severity classifier are engine-agnostic. Not implemented here — drop a sibling script when needed.
+
+## Requirements
+
+- Node 22 or newer (uses the built-in `node:sqlite` module).
+- A sqlc-style query catalog (`-- name: X :type` markers). Other named-query formats can be supported by adjusting `parseQueryCatalog` in the runner.
+
+## Files
+
+- `scripts/explain-runner.mjs` — CLI entrypoint, no dependencies.

--- a/sql-plan-audit/scripts/explain-runner.mjs
+++ b/sql-plan-audit/scripts/explain-runner.mjs
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+// SQLite EXPLAIN QUERY PLAN runner for sqlc-style query catalogs.
+//
+// - Loads a schema file into in-memory SQLite.
+// - Parses a query catalog with `-- name: X :type` markers.
+// - Substitutes `sqlc.arg('x')` and `sqlc.slice('x')` with NULL placeholders
+//   so the planner can resolve types without real binds.
+// - Runs EXPLAIN QUERY PLAN for every query.
+// - Emits a stable JSON / text dump that diffs cleanly across PRs.
+//
+// CLI: explain-runner.mjs --schema <path> --queries <path> [--out <path>]
+//                         [--baseline <path>] [--format json|text]
+//                         [--fail-on regress|scan|none]
+
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync, writeFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+  const args = {
+    schema: null,
+    queries: null,
+    out: null,
+    baseline: null,
+    format: "text",
+    failOn: "regress",
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--schema") args.schema = argv[++i];
+    else if (k === "--queries") args.queries = argv[++i];
+    else if (k === "--out") args.out = argv[++i];
+    else if (k === "--baseline") args.baseline = argv[++i];
+    else if (k === "--format") args.format = argv[++i];
+    else if (k === "--fail-on") args.failOn = argv[++i];
+    else if (k === "--help" || k === "-h") {
+      console.error(
+        "explain-runner.mjs --schema <path> --queries <path> [--out <path>] " +
+          "[--baseline <path>] [--format json|text] [--fail-on regress|scan|none]",
+      );
+      process.exit(0);
+    }
+  }
+  if (!args.schema || !args.queries) {
+    console.error("--schema and --queries are required");
+    process.exit(2);
+  }
+  return args;
+}
+
+// Split a sqlc-style query catalog into [{ name, type, sql }].
+function parseQueryCatalog(text) {
+  const queries = [];
+  const lines = text.split("\n");
+  let current = null;
+  for (const line of lines) {
+    const header = line.match(/^--\s*name:\s*(\S+)\s*:(\S+)\s*$/);
+    if (header) {
+      if (current) queries.push(current);
+      current = { name: header[1], type: header[2], sqlLines: [] };
+      continue;
+    }
+    if (line.startsWith("--")) continue;
+    if (current) current.sqlLines.push(line);
+  }
+  if (current) queries.push(current);
+  return queries
+    .map((q) => ({
+      name: q.name,
+      type: q.type,
+      sql: q.sqlLines.join("\n").trim().replace(/;\s*$/, ""),
+    }))
+    .filter((q) => q.sql.length > 0);
+}
+
+// EXPLAIN QUERY PLAN does not need real bind values; substitute placeholders
+// with NULL so the planner runs. `sqlc.slice('x')` expands to NULL (single
+// element) because the planner only cares about the IN clause shape.
+function rewritePlaceholders(sql) {
+  let rewritten = sql.replace(/sqlc\.arg\(['"][^'"]+['"]\)/g, "NULL");
+  rewritten = rewritten.replace(/sqlc\.slice\(['"][^'"]+['"]\)/g, "NULL");
+  return rewritten;
+}
+
+function explainPlan(db, sql) {
+  const plan = db.prepare(`EXPLAIN QUERY PLAN ${sql}`).all();
+  return plan.map((row) => ({
+    id: row.id,
+    parent: row.parent,
+    detail: row.detail,
+  }));
+}
+
+function planSeverity(detail) {
+  const d = String(detail);
+  if (/^SCAN\b/.test(d)) return "scan";
+  if (/USE TEMP B-TREE FOR (ORDER BY|GROUP BY|DISTINCT)/.test(d))
+    return "temp-btree";
+  if (/^SEARCH\b/.test(d)) return "search";
+  return "info";
+}
+
+function formatTextReport(results) {
+  const lines = [];
+  for (const r of results) {
+    lines.push(`-- ${r.name} :${r.type}`);
+    if (r.error) {
+      lines.push(`  ERROR: ${r.error}`);
+      lines.push("");
+      continue;
+    }
+    for (const p of r.plan) {
+      const sev = planSeverity(p.detail);
+      const marker = sev === "scan" ? "!" : sev === "temp-btree" ? "?" : " ";
+      lines.push(`  ${marker} ${p.detail}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function summarize(results) {
+  const summary = { total: 0, scan: 0, tempBtree: 0, errors: 0 };
+  for (const r of results) {
+    summary.total += 1;
+    if (r.error) {
+      summary.errors += 1;
+      continue;
+    }
+    for (const p of r.plan) {
+      const sev = planSeverity(p.detail);
+      if (sev === "scan") summary.scan += 1;
+      else if (sev === "temp-btree") summary.tempBtree += 1;
+    }
+  }
+  return summary;
+}
+
+function diffBaseline(prev, current) {
+  // Both keyed by query name. Returns regressions = queries whose plan
+  // gained a SCAN or temp-btree that wasn't present before.
+  const regressions = [];
+  for (const r of current) {
+    const before = prev[r.name];
+    if (!before) continue;
+    const before_scans = before.plan.filter(
+      (p) => planSeverity(p.detail) !== "search" &&
+        planSeverity(p.detail) !== "info",
+    ).map((p) => p.detail).sort();
+    const after_scans = (r.plan || []).filter(
+      (p) => planSeverity(p.detail) !== "search" &&
+        planSeverity(p.detail) !== "info",
+    ).map((p) => p.detail).sort();
+    if (after_scans.length > before_scans.length) {
+      regressions.push({ name: r.name, before: before_scans, after: after_scans });
+    }
+  }
+  return regressions;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const schemaPath = resolve(args.schema);
+  const queriesPath = resolve(args.queries);
+  const schema = readFileSync(schemaPath, "utf8");
+  const catalog = parseQueryCatalog(readFileSync(queriesPath, "utf8"));
+
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+
+  const results = [];
+  for (const q of catalog) {
+    const sql = rewritePlaceholders(q.sql);
+    try {
+      const plan = explainPlan(db, sql);
+      results.push({ name: q.name, type: q.type, plan });
+    } catch (e) {
+      results.push({ name: q.name, type: q.type, plan: [], error: e.message });
+    }
+  }
+
+  const summary = summarize(results);
+  const payload = { summary, queries: results };
+  const output =
+    args.format === "json"
+      ? JSON.stringify(payload, null, 2) + "\n"
+      : formatTextReport(results) +
+        `\n-- summary: ${summary.total} queries, ${summary.scan} SCAN, ` +
+        `${summary.tempBtree} TEMP B-TREE, ${summary.errors} errors\n`;
+
+  if (args.out) writeFileSync(resolve(args.out), output);
+  else process.stdout.write(output);
+
+  let exit = 0;
+  if (args.baseline && existsSync(resolve(args.baseline))) {
+    const prevText = readFileSync(resolve(args.baseline), "utf8");
+    const prev = JSON.parse(prevText);
+    const prevByName = Object.fromEntries(
+      (prev.queries || []).map((q) => [q.name, q]),
+    );
+    const regressions = diffBaseline(prevByName, results);
+    if (regressions.length > 0) {
+      console.error(
+        `query plan regressions (${regressions.length}):\n` +
+          regressions
+            .map(
+              (r) =>
+                `  ${r.name}: +${r.after.length - r.before.length} unindexed access\n` +
+                `    before: ${JSON.stringify(r.before)}\n` +
+                `    after:  ${JSON.stringify(r.after)}`,
+            )
+            .join("\n"),
+      );
+      if (args.failOn === "regress" || args.failOn === "scan") exit = 1;
+    }
+  } else if (args.failOn === "scan" && summary.scan > 0) {
+    console.error(`fail-on=scan: ${summary.scan} SCAN entries`);
+    exit = 1;
+  }
+
+  db.close();
+  process.exit(exit);
+}
+
+main();

--- a/sql-schema-audit/SKILL.md
+++ b/sql-schema-audit/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: sql-schema-audit
+description: Index coverage and N+1 review aids for SQLite/D1 schemas with a sqlc catalog. Surfaces unused indexes (with FK CASCADE awareness so cascade-load-bearing indexes are not flagged), queries that scan tables without index help, and `for`-loops calling generated SQL fns.
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [sql, sqlite, d1, dba, schema, indexes, n+1]
+    related_skills: [sql-plan-audit, sql-lint, sql-security]
+    engines: [sqlite]
+---
+
+# SQL Schema Audit
+
+Use this for two recurring DBA review tasks:
+
+1. **Where is index work missing?** Walk every query plan and attribute each `SCAN <table>` to either a known intentional case (no covering index possible) or a gap (table has no indexes at all).
+2. **Where might code N+1?** Find `for`-loops that call sqlc-generated functions — review aid, not a hard fail, because batch inserts are legitimate.
+
+## index-coverage.mjs
+
+```bash
+node scripts/index-coverage.mjs \
+  --schema your-project/db/schema.sql \
+  --queries your-project/db/queries.sql \
+  --out your-project/.linters/index-coverage.txt
+```
+
+Output sections:
+
+- **Per-query SCAN attribution**: each query that produces a `SCAN` step is listed with the SCAN's rationale. `FIX` marker means the table has no indexes at all (immediate work). No marker means the table has indexes but the planner chose to scan anyway — usually fine (small table, unusual WHERE shape).
+- **Drop candidates**: indexes that no catalog query referenced via `SEARCH USING INDEX` *and* don't cover any FK CASCADE source column.
+- **FK-cascade-load-bearing indexes**: unused-by-SELECT indexes whose leading columns match a foreign key's `from` list. SQLite does NOT auto-create indexes on FK columns; without an explicit index, `ON DELETE CASCADE` walks the child table with a full scan. These look "unused" but are load-bearing for delete latency.
+
+The FK-awareness step matters: in a typical schema with many `owner_user_id` foreign keys, most "unused" indexes are actually serving cascade deletes. Dropping them silently regresses delete performance.
+
+## When dropping a candidate
+
+Cross-check before dropping:
+
+1. The audit only inspects sqlc-managed queries. Inline SQL (FTS5 `MATCH`, dynamic `LIKE`, vector lookups) bypasses the audit. Grep the codebase for the index name or its column combination before dropping.
+2. The planner may pick the index dynamically for shapes the static EXPLAIN doesn't replicate (e.g. when a different bind value distribution changes the chosen index). A drop candidate is "no SELECT picks it in the analyzed catalog" — that's necessary, not sufficient.
+3. An index that's logically "redundant to" a superset index can usually be dropped — the planner will fall through to the longer index. Verify with `sql-plan-audit` after the drop to make sure no query regressed to SCAN.
+
+## n-plus-one.mjs
+
+```bash
+node scripts/n-plus-one.mjs your-project/src
+```
+
+Regex-based scan for `for`-loops that call a sqlc-generated function within 12 lines. Tunable:
+
+- `--callee-prefix @db.,db.` to match other binding styles (Rust `state.db.`, Go `q.`, etc.).
+- `--window 20` to widen the look-ahead.
+
+The script returns 0 always — N+1 candidates need human review. Use it as a review aid, not a CI gate.
+
+Most candidates in well-typed codebases are legitimate batch inserts (`create_skill_file` inside `for file in files`, `add_skill_tag` inside `for tag in tags`). One genuine SELECT-in-loop is the kind of thing this report exists to catch.
+
+## When to invoke
+
+- After a schema change (added or removed index).
+- Before a release: a one-time "what's unused?" pass.
+- When a feature lands a `for`-loop touching the DB — eyeball the n-plus-one report.
+
+## Not in scope
+
+- **Schema drift between code and production**: needs reading the live DB schema and diffing against `schema.sql`. Out of scope here.
+- **CHECK / NOT NULL audit**: schemalint or similar. Probably worth a follow-up skill.
+- **EXPLAIN ANALYZE / actual row counts**: SQLite doesn't expose them statically.
+
+## Engine extensibility
+
+The PRAGMA-based introspection (`PRAGMA index_list`, `PRAGMA index_info`, `PRAGMA foreign_key_list`) is SQLite-specific. For Postgres: query `pg_indexes` + `pg_stat_user_indexes` (which gives actual usage counts — much more accurate than the EXPLAIN-based heuristic) + `information_schema.referential_constraints`. For MySQL: `information_schema.STATISTICS` + `information_schema.KEY_COLUMN_USAGE`.
+
+The N+1 detector is engine-agnostic, but the `--callee-prefix` heuristic depends on codegen conventions (sqlc / sqlx / typeorm / prisma).
+
+## Requirements
+
+- Node 22 or newer (uses the built-in `node:sqlite` module).
+- A sqlc-style query catalog or compatible format.
+
+## Files
+
+- `scripts/index-coverage.mjs` — per-query SCAN attribution + drop candidates + FK-cascade-load-bearing list.
+- `scripts/n-plus-one.mjs` — `for`-loop sqlc-call detector.

--- a/sql-schema-audit/scripts/index-coverage.mjs
+++ b/sql-schema-audit/scripts/index-coverage.mjs
@@ -1,0 +1,288 @@
+#!/usr/bin/env node
+// Index-coverage report for a sqlc-style query catalog.
+//
+// For every query, walk the EXPLAIN QUERY PLAN, identify SCAN steps, and
+// look up whether the table has an index that could cover the WHERE / JOIN
+// columns. Output: per-query table-scan justification (and a TODO marker
+// when the scan looks fixable).
+//
+// This complements `sql-plan-audit` (which baselines plans) by attributing
+// *why* a scan happens.
+//
+// CLI: index-coverage.mjs --schema <path> --queries <path> [--out <path>]
+
+import { DatabaseSync } from "node:sqlite";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+function parseArgs(argv) {
+  const args = { schema: null, queries: null, out: null };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--schema") args.schema = argv[++i];
+    else if (k === "--queries") args.queries = argv[++i];
+    else if (k === "--out") args.out = argv[++i];
+    else if (k === "--help" || k === "-h") {
+      console.error(
+        "index-coverage.mjs --schema <path> --queries <path> [--out <path>]",
+      );
+      process.exit(0);
+    }
+  }
+  if (!args.schema || !args.queries) {
+    console.error("--schema and --queries are required");
+    process.exit(2);
+  }
+  return args;
+}
+
+function parseCatalog(text) {
+  const queries = [];
+  let current = null;
+  for (const line of text.split("\n")) {
+    const header = line.match(/^--\s*name:\s*(\S+)\s*:(\S+)\s*$/);
+    if (header) {
+      if (current) queries.push(current);
+      current = { name: header[1], type: header[2], sqlLines: [] };
+      continue;
+    }
+    if (line.startsWith("--")) continue;
+    if (current) current.sqlLines.push(line);
+  }
+  if (current) queries.push(current);
+  return queries
+    .map((q) => ({
+      name: q.name, type: q.type,
+      sql: q.sqlLines.join("\n").trim().replace(/;\s*$/, ""),
+    }))
+    .filter((q) => q.sql.length > 0);
+}
+
+function rewritePlaceholders(sql) {
+  return sql
+    .replace(/sqlc\.arg\(['"][^'"]+['"]\)/g, "NULL")
+    .replace(/sqlc\.slice\(['"][^'"]+['"]\)/g, "NULL");
+}
+
+function collectIndexCoverage(db) {
+  // Returns { tableName: [{ name, columns: [string] }] } including PK and
+  // unique constraints (which sqlite stores as sqlite_autoindex_*).
+  const tables = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+    .all();
+  const out = {};
+  for (const t of tables) {
+    const indexes = db
+      .prepare(`PRAGMA index_list("${t.name}")`)
+      .all();
+    out[t.name] = indexes.map((idx) => {
+      const cols = db.prepare(`PRAGMA index_info("${idx.name}")`).all();
+      return {
+        name: idx.name,
+        unique: idx.unique === 1,
+        columns: cols.map((c) => c.name),
+      };
+    });
+  }
+  return out;
+}
+
+// Returns { tableName: [{ from: [col], to: [col], onDelete: "CASCADE"|... }] }.
+// SQLite does not auto-create indexes on FK columns; absent an explicit index,
+// ON DELETE CASCADE / ON UPDATE CASCADE walks the child table with a full
+// scan. So an index whose columns are a prefix of an FK's `from` list is
+// load-bearing for cascade performance even when no SELECT references it.
+function collectForeignKeys(db) {
+  const tables = db
+    .prepare("SELECT name FROM sqlite_master WHERE type = 'table'")
+    .all();
+  const out = {};
+  for (const t of tables) {
+    const fks = db.prepare(`PRAGMA foreign_key_list("${t.name}")`).all();
+    // Group multi-column FKs by `id`.
+    const grouped = {};
+    for (const row of fks) {
+      if (!grouped[row.id]) {
+        grouped[row.id] = {
+          from: [],
+          to: [],
+          onDelete: row.on_delete,
+          onUpdate: row.on_update,
+          referenced: row.table,
+        };
+      }
+      grouped[row.id].from[row.seq] = row.from;
+      grouped[row.id].to[row.seq] = row.to;
+    }
+    out[t.name] = Object.values(grouped);
+  }
+  return out;
+}
+
+// Does `index.columns` start with the FK's `from` columns?
+function indexCoversFk(idxCols, fkFrom) {
+  if (idxCols.length < fkFrom.length) return false;
+  for (let i = 0; i < fkFrom.length; i++) {
+    if (idxCols[i] !== fkFrom[i]) return false;
+  }
+  return true;
+}
+
+function classifyPlan(plan) {
+  const scans = [];
+  const searches = [];
+  for (const p of plan) {
+    const d = String(p.detail);
+    let m = d.match(/^SCAN\s+(?:VIRTUAL\s+TABLE\s+)?(\S+)/);
+    if (m) {
+      scans.push({ kind: "scan", table: m[1].replace(/^TABLE\s+/, ""), detail: d });
+      continue;
+    }
+    m = d.match(/^SEARCH\s+(\S+)\s+USING\s+(?:COVERING\s+)?INDEX\s+(\S+)/);
+    if (m) {
+      searches.push({ table: m[1], index: m[2], detail: d });
+      continue;
+    }
+    m = d.match(/^SEARCH\s+(\S+)\s+USING\s+(?:INTEGER\s+)?PRIMARY KEY/);
+    if (m) {
+      searches.push({ table: m[1], index: "<pk>", detail: d });
+    }
+  }
+  return { scans, searches };
+}
+
+function analyseScan(scan, indexInfo) {
+  const idxs = indexInfo[scan.table] || [];
+  if (idxs.length === 0) {
+    return { rationale: "table has no indexes", fixable: true };
+  }
+  return {
+    rationale: `table has ${idxs.length} index${idxs.length === 1 ? "" : "es"}: ${idxs.map((i) => `${i.name}(${i.columns.join(",")})`).join(", ")}`,
+    fixable: false,  // intentionally vague — needs human review.
+  };
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const schema = readFileSync(resolve(args.schema), "utf8");
+  const catalog = parseCatalog(readFileSync(resolve(args.queries), "utf8"));
+
+  const db = new DatabaseSync(":memory:");
+  db.exec(schema);
+  const indexInfo = collectIndexCoverage(db);
+  const fkInfo = collectForeignKeys(db);
+
+  const reports = [];
+  for (const q of catalog) {
+    let plan;
+    try {
+      plan = db
+        .prepare(`EXPLAIN QUERY PLAN ${rewritePlaceholders(q.sql)}`)
+        .all();
+    } catch (e) {
+      reports.push({ name: q.name, type: q.type, error: e.message });
+      continue;
+    }
+    const { scans, searches } = classifyPlan(plan);
+    if (scans.length === 0 && searches.length === 0) continue;
+    const scanReports = scans.map((s) => ({
+      ...s, ...analyseScan(s, indexInfo),
+    }));
+    reports.push({
+      name: q.name, type: q.type,
+      scans: scanReports, searches,
+    });
+  }
+
+  const lines = [];
+  let unindexedTotal = 0;
+  for (const r of reports) {
+    if (r.error) {
+      lines.push(`-- ${r.name}: ERROR ${r.error}`);
+      continue;
+    }
+    if (r.scans.length === 0) continue;
+    lines.push(`-- ${r.name} :${r.type}`);
+    for (const s of r.scans) {
+      const marker = s.fixable ? "FIX" : "   ";
+      lines.push(`  ${marker} SCAN ${s.table}: ${s.rationale}`);
+      if (s.fixable) unindexedTotal += 1;
+    }
+    lines.push("");
+  }
+
+  // Index usage histogram. SQLite EXPLAIN reports `SEARCH <alias> USING
+  // INDEX <name>` where <alias> may be a table alias (e.g. `SEARCH j USING
+  // INDEX idx_...`) rather than the real table name. Index names are
+  // globally unique in SQLite, so key the usage map by index name alone
+  // to avoid alias-induced false-positive "unused" results.
+  const usage = {};
+  for (const r of reports) {
+    if (r.error || !r.searches) continue;
+    for (const s of r.searches) {
+      usage[s.index] = (usage[s.index] || 0) + 1;
+    }
+  }
+  const unused = [];
+  for (const [tbl, idxs] of Object.entries(indexInfo)) {
+    for (const idx of idxs) {
+      if (!(idx.name in usage)) {
+        // Skip auto-indexes; their existence is intrinsic to the PK / UNIQUE.
+        if (idx.name.startsWith("sqlite_autoindex_")) continue;
+        unused.push({ table: tbl, index: idx.name, columns: idx.columns });
+      }
+    }
+  }
+  // Attribute each "unused" index — FK CASCADE column coverage means the
+  // index is load-bearing for delete cascade performance even when no
+  // SELECT picks it. Without this attribution, dropping the index would
+  // silently regress cascade-delete latency.
+  const unusedClassified = [];
+  for (const u of unused) {
+    const fks = fkInfo[u.table] || [];
+    let fkCoveredBy = null;
+    for (const fk of fks) {
+      if (indexCoversFk(u.columns, fk.from)) {
+        fkCoveredBy = fk;
+        break;
+      }
+    }
+    unusedClassified.push({ ...u, fkCoveredBy });
+  }
+
+  const droppable = unusedClassified.filter((u) => !u.fkCoveredBy);
+  const fkLoadBearing = unusedClassified.filter((u) => u.fkCoveredBy);
+
+  if (droppable.length > 0) {
+    lines.push(
+      "-- unused indexes — candidates for DROP (no SELECT picks them, no FK cascade depends on them)",
+    );
+    for (const u of droppable) {
+      lines.push(`     ${u.table}.${u.index}(${u.columns.join(",")})`);
+    }
+    lines.push("");
+  }
+  if (fkLoadBearing.length > 0) {
+    lines.push(
+      "-- unused-by-SELECT but load-bearing for FK CASCADE (keep)",
+    );
+    for (const u of fkLoadBearing) {
+      const fk = u.fkCoveredBy;
+      lines.push(
+        `     ${u.table}.${u.index}(${u.columns.join(",")})  -- FK ${fk.from.join(",")} -> ${fk.referenced}(${fk.to.join(",")}) ON DELETE ${fk.onDelete}`,
+      );
+    }
+    lines.push("");
+  }
+
+  const summary = `-- summary: ${reports.length} queries with scan/search activity, ${unindexedTotal} fixable scans, ${droppable.length} drop candidates, ${fkLoadBearing.length} FK-cascade-load-bearing indexes`;
+  lines.push(summary);
+  const output = lines.join("\n") + "\n";
+
+  if (args.out) writeFileSync(resolve(args.out), output);
+  else process.stdout.write(output);
+
+  db.close();
+}
+
+main();

--- a/sql-schema-audit/scripts/n-plus-one.mjs
+++ b/sql-schema-audit/scripts/n-plus-one.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Text-based N+1 detector for MoonBit / Rust / TS code that calls sqlc
+// generated functions inside a `for` loop. ast-grep would be cleaner, but
+// MoonBit has no tree-sitter grammar yet (2025-11), so we lean on regex.
+//
+// Heuristic: a `for` line followed within N lines by `@db.<fn_name>(` (or
+// `db.<fn_name>(` for TS/Rust) without a separating closing brace counts as
+// a candidate. False positives expected — this is a review aid, not a gate.
+//
+// CLI: n-plus-one.mjs [--glob "src/**/*.mbt"] [--callee-prefix @db.] [--window 10]
+//                     <file> [<file> ...]
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve, extname, join } from "node:path";
+
+function parseArgs(argv) {
+  const args = {
+    callees: ["@db.", "db."],
+    window: 12,
+    files: [],
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--callee-prefix") args.callees = argv[++i].split(",");
+    else if (k === "--window") args.window = Number(argv[++i]);
+    else if (k === "--help" || k === "-h") {
+      console.error(
+        "n-plus-one.mjs [--callee-prefix @db.,db.] [--window 12] <file|dir> ...",
+      );
+      process.exit(0);
+    } else args.files.push(k);
+  }
+  if (args.files.length === 0) {
+    console.error("at least one file or directory is required");
+    process.exit(2);
+  }
+  return args;
+}
+
+function* walk(path) {
+  const stat = statSync(path);
+  if (stat.isFile()) {
+    yield path;
+    return;
+  }
+  for (const entry of readdirSync(path)) {
+    if (entry.startsWith(".") || entry === "node_modules" || entry === "_build" || entry === "dist") {
+      continue;
+    }
+    const full = join(path, entry);
+    yield* walk(full);
+  }
+}
+
+function scan(path, source, callees, window) {
+  const lines = source.split("\n");
+  const findings = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    const forMatch = line.match(/^\s*(for\s+\S+\s+in\s+|for\s*\(\s*const\s+\S+\s+of\s+)/);
+    if (!forMatch) continue;
+    const end = Math.min(i + 1 + window, lines.length);
+    for (let j = i + 1; j < end; j++) {
+      const inner = lines[j];
+      // Stop at closing brace at same indent level.
+      if (inner.match(/^\s{0,4}\}\s*$/)) break;
+      for (const callee of callees) {
+        const escaped = callee.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+        const re = new RegExp(`${escaped}([a-z_][a-z0-9_]*)\\s*\\(`);
+        const m = inner.match(re);
+        if (m) {
+          findings.push({
+            path, line: i + 1, callee: `${callee}${m[1]}`,
+            inner_line: j + 1,
+          });
+          break;
+        }
+      }
+    }
+  }
+  return findings;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const exts = [".mbt", ".ts", ".tsx", ".rs", ".mjs", ".js"];
+  let findings = [];
+  for (const target of args.files) {
+    for (const file of walk(resolve(target))) {
+      if (!exts.includes(extname(file))) continue;
+      const text = readFileSync(file, "utf8");
+      findings = findings.concat(scan(file, text, args.callees, args.window));
+    }
+  }
+  if (findings.length === 0) {
+    console.log("n+1 scan: no candidates");
+    process.exit(0);
+  }
+  for (const f of findings) {
+    console.log(`${f.path}:${f.line}: for-loop calls ${f.callee}() at line ${f.inner_line}`);
+  }
+  console.error(`n+1 scan: ${findings.length} candidate${findings.length === 1 ? "" : "s"} (review manually)`);
+  // Exit 0 — this is review aid, not a fail-gate.
+}
+
+main();

--- a/sql-security/SKILL.md
+++ b/sql-security/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: sql-security
+description: SQL injection screening for host code (MoonBit / TS / Rust) plus secretlint setup notes. Flags any template-literal or string-concat SQL builder, regardless of value source — the scanner does not trace data flow, so every hit needs a manual review or an explicit `// sql-security: ok` opt-out.
+version: 0.1.0
+metadata:
+  hermes:
+    tags: [sql, security, sqlite, d1, dba, sqli, secrets]
+    related_skills: [sql-plan-audit, sql-lint, sql-schema-audit]
+    engines: [sqlite, postgres, mysql]
+---
+
+# SQL Security
+
+Use this when a project ships SQL through host code (MoonBit / TS / Rust / Go) and wants a cheap line of defence against the two recurring sources of SQL-domain incidents:
+
+1. **SQL injection**: a string template that interpolates a value into a SQL fragment instead of binding it through a placeholder.
+2. **Secrets in queries**: a hardcoded token or connection string that leaks into git history. Handled by `secretlint`, not this skill — see "Companion: secretlint" below.
+
+## sql-injection-scan.mjs
+
+```bash
+node scripts/sql-injection-scan.mjs your-project/src
+```
+
+The scanner walks the directory, ignores generated files (`db/gen/`, `sqlc_*.mbt`, `*.test.mbt`, `_build/`, `dist/`, `target/`), and flags:
+
+- **template-interp**: a backtick string literal that *starts with* a SQL keyword (`SELECT`, `INSERT INTO`, `WHERE`, `AND (`, ...) AND contains a `${...}` placeholder. Example: `` `WHERE c.vector_id IN (${placeholders})` ``.
+- **string-concat**: a quoted SQL string adjacent to a `+` and an identifier. Example: `"SELECT * FROM " + table`.
+
+The keyword match is **case-sensitive on purpose** — `from` / `where` / `join` appear constantly in English prose and would generate hundreds of false positives if matched case-insensitively.
+
+The scanner exits 1 on findings — every hit deserves a manual review even if it turns out to be safe.
+
+## Reading the findings
+
+A finding does not automatically mean injection. Many legitimate cases exist:
+
+- **Internal placeholder expansion**: building `?,?,?,...,?` for an IN clause from a server-derived count. The interpolated value is `?`, never user input. Annotate with the opt-out comment so future scans can ignore it.
+- **FTS5 / vector queries that sqlc cannot parse**: dynamic clause builders that interpolate column lists or `?` counts. User input still passes through `.bind(...)`.
+- **Inline migration scripts** building DDL at deploy time.
+
+The scanner is intentionally noisy because the cost of missing one real SQLi is much higher than the cost of triaging a list of 5 false positives.
+
+## Opt-out marker
+
+To silence a known-safe line, add a comment with the marker `sql-security: ok` either on the same line or on the line above:
+
+```ts
+// sql-security: ok (placeholders is server-derived `?` count, values bind separately)
+const sql = `WHERE c.vector_id IN (${placeholders})`;
+```
+
+The scanner accepts `//` (TS / MoonBit / Rust / Go) and `#` (Python / shell) comment markers.
+
+## Companion: secretlint
+
+For credential leakage (the other half of "SQL security"), use `secretlint`. Recommended setup for a pkfire-managed repo's pre-push hook:
+
+```bash
+pnpm add -D secretlint @secretlint/secretlint-rule-preset-recommend
+```
+
+Then run on pre-push:
+
+```bash
+pnpm exec secretlint --secretlintignore .gitignore "**/*"
+```
+
+This is per-repo and complements any user-global secretlint configuration. The `mizchi/skills/pkfire` skill has a ready-made recipe at `assets/recipes/14-secretlint-pre-push.pkl` for projects using pkfire hooks.
+
+## When to invoke
+
+- **pre-push**: cheap, runs once before sending code to the remote.
+- **pre-commit**: optional. `secretlint` here can be slow on large diffs; `sql-injection-scan` is cheap enough.
+- **PR review**: paste the scanner output into the review checklist.
+
+## Not in scope
+
+- **Stored XSS / template injection**: these go through frontend / templating layers, not SQL.
+- **Authz bypasses**: row-level access checks are app logic, not a SQL concern.
+- **DoS via expensive query**: covered by `sql-plan-audit` (look for new SCAN entries) and rate limiting at the edge.
+
+## Engine extensibility
+
+The scanner regex is engine-agnostic. The SQL-keyword set works for SQLite / Postgres / MySQL out of the box. Add `RETURNING` / `OVERLAPS` / `LIMIT OFFSET` if a Postgres-heavy project needs broader coverage.
+
+## Requirements
+
+- Node 20 or newer.
+
+## Files
+
+- `scripts/sql-injection-scan.mjs` — zero-dep text scanner.

--- a/sql-security/scripts/sql-injection-scan.mjs
+++ b/sql-security/scripts/sql-injection-scan.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+// Cheap text-based SQL-injection screening for host code (MoonBit / TS / etc).
+//
+// Looks inside string literals that contain SQL keywords (SELECT / INSERT /
+// UPDATE / DELETE / WHERE) and flags string-concat patterns adjacent to them:
+//   - `... ${variable} ...` template interpolation
+//   - `"..." + variable`  ad-hoc concat
+//   - `[".." + variable, ".."]` builder arrays
+//
+// Quote-stripped `?` placeholders are safe and ignored. The goal is to catch
+// the post-sqlc residue: a stray inline string concat for a SELECT that
+// somehow got past code review.
+//
+// CLI: sql-injection-scan.mjs [--ext .mbt,.ts,.tsx] <file|dir> ...
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { resolve, extname, join } from "node:path";
+
+function parseArgs(argv) {
+  const args = {
+    exts: [".mbt", ".ts", ".tsx", ".rs", ".mjs", ".js"],
+    files: [],
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i];
+    if (k === "--ext") args.exts = argv[++i].split(",");
+    else if (k === "--help" || k === "-h") {
+      console.error(
+        "sql-injection-scan.mjs [--ext .mbt,.ts,.tsx] <file|dir> ...",
+      );
+      process.exit(0);
+    } else args.files.push(k);
+  }
+  if (args.files.length === 0) {
+    console.error("at least one file or directory is required");
+    process.exit(2);
+  }
+  return args;
+}
+
+function* walk(path, exts) {
+  let stat;
+  try { stat = statSync(path); } catch { return; }
+  if (stat.isFile()) {
+    if (exts.includes(extname(path))) yield path;
+    return;
+  }
+  for (const entry of readdirSync(path)) {
+    if (entry.startsWith(".") || entry === "node_modules" ||
+        entry === "_build" || entry === "dist" || entry === "target") {
+      continue;
+    }
+    yield* walk(join(path, entry), exts);
+  }
+}
+
+// Case-sensitive: SQL is uppercase by convention, so requiring caps weeds
+// out English "from" / "where" / "join" prose.
+const SQL_KW_STRICT = /\b(SELECT|INSERT\s+INTO|INSERT\s+OR|UPDATE|DELETE\s+FROM|FROM|WHERE|JOIN|HAVING|GROUP\s+BY|ORDER\s+BY)\b/;
+// Template literal that *starts* with a SQL keyword (with optional
+// leading whitespace / parens / fragments like "AND (").
+const SQL_STARTS_TPL = /`\s*(SELECT|INSERT\s+(?:OR\s+)?INTO|UPDATE|DELETE\s+FROM|WITH|AND\s+\(|OR\s+\(|WHERE|FROM|JOIN|GROUP|ORDER|HAVING)/;
+
+function scanLine(line) {
+  // Template literal that contains a placeholder AND starts with SQL.
+  const tplMatch = line.match(/`[^`]*\${[^}]+}[^`]*`/);
+  if (tplMatch && SQL_STARTS_TPL.test(tplMatch[0])) {
+    return { rule: "template-interp", excerpt: tplMatch[0].slice(0, 120) };
+  }
+  // Concat: "SELECT ..." + variable
+  const concat = line.match(/"[^"]*"\s*\+\s*[A-Za-z_$][A-Za-z0-9_$.]*/);
+  if (concat && SQL_KW_STRICT.test(concat[0])) {
+    return { rule: "string-concat", excerpt: concat[0].slice(0, 120) };
+  }
+  return null;
+}
+
+function shouldIgnoreFile(path) {
+  // Generated files are intentionally outside scope.
+  return path.includes("/db/gen/") || path.includes("/_build/") ||
+    path.endsWith(".test.mjs") || path.endsWith(".test.mbt") ||
+    path.includes("/sqlc_queries.mbt") || path.includes("/sqlc_types.mbt");
+}
+
+// A line can be opted out with one of:
+//   // sql-security: ok [<short reason>]
+//   # sql-security: ok [<short reason>]
+// The marker may appear on the same line OR on the previous line.
+const ALLOW_MARKER = /(?:\/\/|#)\s*sql-security:\s*ok/;
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  let findings = [];
+  for (const target of args.files) {
+    for (const file of walk(resolve(target), args.exts)) {
+      if (shouldIgnoreFile(file)) continue;
+      const lines = readFileSync(file, "utf8").split("\n");
+      lines.forEach((line, i) => {
+        const hit = scanLine(line);
+        if (!hit) return;
+        // Opt-out marker on the line itself or the previous one.
+        if (ALLOW_MARKER.test(line)) return;
+        const prev = lines[i - 1] || "";
+        if (ALLOW_MARKER.test(prev)) return;
+        findings.push({ path: file, line: i + 1, ...hit });
+      });
+    }
+  }
+  if (findings.length === 0) {
+    console.log("sql injection scan: no candidates");
+    process.exit(0);
+  }
+  for (const f of findings) {
+    console.log(`${f.path}:${f.line}: [${f.rule}] ${f.excerpt}`);
+  }
+  console.error(
+    `sql injection scan: ${findings.length} candidate${findings.length === 1 ? "" : "s"} (review manually)`,
+  );
+  // Exit 1 — these are review-required findings, not info.
+  process.exit(1);
+}
+
+main();


### PR DESCRIPTION
Four DBA-perspective skills for SQLite/D1 + sqlc projects, promoted from `mizchi/mnemo` where they were developed against a ~250-query catalog and verified during a recent inline-SQL → sqlc migration.

| Skill | Purpose | CI gate |
|---|---|---|
| `sql-lint` | Catalog hygiene (duplicate names, missing `;`, `SELECT *`, double-wildcard `LIKE`) + optional sqlfluff | yes |
| `sql-plan-audit` | `EXPLAIN QUERY PLAN` baseline + regression diff against committed plans | yes |
| `sql-schema-audit` | Index coverage attribution (FK-CASCADE-aware) + N+1 review aid | review |
| `sql-security` | SQLi screening with `// sql-security: ok` opt-out marker | yes |

## Design highlights

- **Zero-dep**. All scripts use Node 20+/22+ built-ins (`node:sqlite`). No npm install needed.
- **Generic CLI**. `--schema` / `--queries` / `--out` / `--baseline` / `--fail-on` flags. Wiring into a project is a 5-line `justfile` recipe.
- **SQLite-first, engine extension noted**. Each SKILL.md documents the Postgres / MySQL extension path (which would use `pg_stat_user_indexes` for actual usage counts instead of static EXPLAIN — much more accurate).

## Notable lessons captured

- **FK-CASCADE awareness in `sql-schema-audit`** caught a near-mistake during mnemo development. The audit's first version flagged ~43 indexes as unused; manual review showed ~23 of them were load-bearing for `ON DELETE CASCADE`. SQLite does NOT auto-create indexes on FK columns; without an explicit index, cascade deletes scan the child table. The skill now reads `PRAGMA foreign_key_list` and splits the output.
- **`// sql-security: ok` opt-out marker** exists because a useful SQLi scanner is necessarily noisy on legitimate cases (FTS5 dynamic `LIKE`, vector `IN`-clause placeholder expansion, `?`-count builders). Per-line annotation is more sustainable than a global allowlist.
- **`sql-plan-audit` stream / exit-code semantics** are documented in a table after empirical evaluation showed blank-slate executors retrying to confirm silent-success and reading the script source to learn that `--fail-on regress` writes diagnostics to stderr.

## Verification (in the source repo, mnemo-server)

- 245 queries / 2 SCAN (both documented as intentional) / 43 TEMP B-TREE / 0 errors via `sql-plan-audit`.
- 0 findings via `sql-lint` across the same 245 queries.
- 7 indexes safely dropped after FK-cascade-aware classification; `sql-plan-audit-check` clean post-drop.
- 4 SQLi candidates annotated with `// sql-security: ok` (all FTS5 dynamic builders with internal `?`-count interpolation, no user-supplied SQL fragments).

🤖 Generated with [Claude Code](https://claude.com/claude-code)