### PR TITLE
Migrate skill model defaults to claude-opus-4-8

### DIFF
--- a/.waxa.yaml
+++ b/.waxa.yaml
@@ -7,7 +7,7 @@ paths:
   results: results/
 defaults:
   engine: copilot-sdk
-  model: claude-sonnet-4.6
+  model: claude-opus-4-8
   timeout: 300
   parallel: false
   workers: 2

--- a/cloudflare/deploy/references/ai-gateway/README.md
+++ b/cloudflare/deploy/references/ai-gateway/README.md
@@ -50,7 +50,7 @@ const { text } = await generateText({
 const { text } = await generateText({
   model: gateway([
     openai('gpt-4o'),              // Try first
-    anthropic('claude-sonnet-4-5'), // Fallback
+    anthropic('claude-opus-4-8'), // Fallback
   ]),
   prompt: 'Hello'
 });
@@ -75,7 +75,7 @@ const client = new OpenAI({
 
 // Switch providers by changing model format: {provider}/{model}
 const response = await client.chat.completions.create({
-  model: 'openai/gpt-4o', // or 'anthropic/claude-sonnet-4-5'
+  model: 'openai/gpt-4o', // or 'anthropic/claude-opus-4-8'
   messages: [{ role: 'user', content: 'Hello!' }]
 });
 ```

--- a/cloudflare/deploy/references/ai-gateway/features.md
+++ b/cloudflare/deploy/references/ai-gateway/features.md
@@ -77,7 +77,7 @@ Or via API: set `model`, `input_cost`, `output_cost`.
 | Provider | Unified API | Notes |
 |----------|-------------|-------|
 | OpenAI | `openai/gpt-4o` | Full support |
-| Anthropic | `anthropic/claude-sonnet-4-5` | Full support |
+| Anthropic | `anthropic/claude-opus-4-8` | Full support |
 | Google AI | `google-ai-studio/gemini-2.0-flash` | Full support |
 | Workers AI | `workersai/@cf/meta/llama-3` | Native |
 | Azure OpenAI | `azure-openai/*` | Deployment names |

--- a/cloudflare/deploy/references/ai-gateway/sdk-integration.md
+++ b/cloudflare/deploy/references/ai-gateway/sdk-integration.md
@@ -25,7 +25,7 @@ const { text } = await generateText({
 const { text } = await generateText({
   model: gateway([
     openai('gpt-4o'),
-    anthropic('claude-sonnet-4-5'),
+    anthropic('claude-opus-4-8'),
     openai('gpt-4o-mini')
   ]),
   prompt: 'Complex task'
@@ -53,7 +53,7 @@ const client = new OpenAI({
 });
 
 // Unified API - switch providers via model name
-model: 'openai/gpt-4o'  // or 'anthropic/claude-sonnet-4-5'
+model: 'openai/gpt-4o'  // or 'anthropic/claude-opus-4-8'
 ```
 
 ## Anthropic SDK

--- a/meta/skill-finder/SKILL.md
+++ b/meta/skill-finder/SKILL.md
@@ -118,7 +118,7 @@ config:
   timeout_seconds: 180
   parallel: false
   executor: claude-cli   # mock for smoke; claude-cli for real eval
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
 
 graders:
   - name: <task-specific>

--- a/meta/skill-finder/evals/eval.yaml
+++ b/meta/skill-finder/evals/eval.yaml
@@ -16,9 +16,9 @@ config:
   timeout_seconds: 360
   parallel: false
   # mock for smoke verification of the YAML structure; switch to claude-cli
-  # for real evaluation runs (model: claude-sonnet-4-6).
+  # for real evaluation runs (model: claude-opus-4-8).
   executor: mock
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
 
 tasks:
   - "tasks/*.yaml"

--- a/meta/skill-selector/evals/eval.yaml
+++ b/meta/skill-selector/evals/eval.yaml
@@ -24,7 +24,7 @@ config:
   # adapter once available) for real evaluation.
   executor: mock
   # claude CLI requires hyphenated form (waza tolerates dotted form).
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
 
 metrics:
   - name: phase1_first

--- a/meta/waxa-eval/SKILL.md
+++ b/meta/waxa-eval/SKILL.md
@@ -227,7 +227,7 @@ The npm package bundles `references/empirical-prompt-tuning.md` so the methodolo
 
 `--baseline` runs every task twice per trial (with_skill and without_skill), then prints a Delta line and writes both configs into `iteration-N/<task-id>/`. This is the agentskills.io-style "does the skill body actually improve over a blank-slate model?" check. Skills that add tokens / latency without moving pass rate are visible here in a way they aren't in single-config runs.
 
-Per-iteration cost (claude-sonnet-4-6, 3 scenarios × 2 trials): ~3-5 minutes wall time. Run iterations sequentially; do not launch parallel `waxa` processes against the same eval (they fight for the API and the lockfile). Single-task runs (`--task <id>`) are useful for confirming a small change without re-running the whole suite.
+Per-iteration cost (claude-opus-4-8, 3 scenarios × 2 trials): ~3-5 minutes wall time. Run iterations sequentially; do not launch parallel `waxa` processes against the same eval (they fight for the API and the lockfile). Single-task runs (`--task <id>`) are useful for confirming a small change without re-running the whole suite.
 
 `trials_per_task: 2` is the floor — a single trial cannot distinguish "the skill is unstable" from "the LLM had a bad sample." Bump to 3 only if you suspect non-determinism on a critical axis.
 

--- a/tooling/nix-setup/evals/eval.yaml
+++ b/tooling/nix-setup/evals/eval.yaml
@@ -16,7 +16,7 @@ config:
   timeout_seconds: 300
   parallel: false
   executor: mock
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
 
 graders:
   - type: code

--- a/tools/waxa/README.md
+++ b/tools/waxa/README.md
@@ -73,7 +73,7 @@ npx @mizchi/waxa <path/to/eval.yaml> --baseline
 npx @mizchi/waxa iterate <path/to/eval.yaml> [--max 5] [--task <task-id>]
 
 # Multi-model comparison (objective axes only — no LLM A-vs-B judge).
-npx @mizchi/waxa compare <path/to/eval.yaml> --models claude-sonnet-4-6,claude-opus-4-7
+npx @mizchi/waxa compare <path/to/eval.yaml> --models claude-opus-4-8,claude-opus-4-7
 
 # Skill A/B variant exploration (current vs experimental rewrite).
 npx @mizchi/waxa variant <path/to/eval.yaml> --base skill-current --candidate skill-rewritten
@@ -169,7 +169,7 @@ paths:
   evals: evals/
   results: results/
 defaults:
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
   timeout: 60
 ```
 
@@ -279,7 +279,7 @@ waxa will:
 - **Compare models** (objective axes only — no LLM A-vs-B):
 
   ```bash
-  waxa compare evals/echo-skill/eval.yaml --models claude-sonnet-4-6,claude-haiku-4-5-20251001
+  waxa compare evals/echo-skill/eval.yaml --models claude-opus-4-8,claude-haiku-4-5-20251001
   ```
 
 - **A/B a candidate skill rewrite**:

--- a/tools/waxa/examples/echo-skill/.waxa.yaml
+++ b/tools/waxa/examples/echo-skill/.waxa.yaml
@@ -3,5 +3,5 @@ paths:
   evals: evals/
   results: results/
 defaults:
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
   timeout: 60

--- a/tools/waxa/examples/echo-skill/README.md
+++ b/tools/waxa/examples/echo-skill/README.md
@@ -32,7 +32,7 @@ waxa iterate evals/echo-skill/eval.yaml --max 3
 
 # multi-model comparison (objective axes only — no LLM A-vs-B)
 waxa compare evals/echo-skill/eval.yaml \
-  --models claude-sonnet-4-6,claude-haiku-4-5-20251001
+  --models claude-opus-4-8,claude-haiku-4-5-20251001
 
 # A/B a candidate skill
 cp -r skills/echo-skill skills/echo-skill-v2

--- a/tools/waxa/src/cli.ts
+++ b/tools/waxa/src/cli.ts
@@ -639,7 +639,7 @@ async function runTask(
   skillBody: string,
   withSkill = true,
 ): Promise<TaskResult> {
-  const model = evalCfg.config?.model ?? "claude-sonnet-4-6";
+  const model = evalCfg.config?.model ?? "claude-opus-4-8";
   const timeout = evalCfg.config?.timeout_seconds ?? 300;
   const requireSelfReport = task.expected?.require_self_report !== false;
   const trialsPerTask = Math.max(1, evalCfg.config?.trials_per_task ?? 1);
@@ -1239,7 +1239,7 @@ config:
   timeout_seconds: 240
   parallel: false
   executor: claude
-  model: claude-sonnet-4-6
+  model: claude-opus-4-8
 
 tasks:
   - "tasks/*.yaml"


### PR DESCRIPTION
Migrates the Claude model-ID references across skills to `claude-opus-4-8`.

## Context

None of the skills contain Anthropic SDK caller code (`client.messages.create(...)`) — waxa shells out to the `claude` CLI, and the rest are eval configs and docs. So this is a **model-ID string migration only**; no `thinking`/`budget_tokens`/`temperature`/prefill breaking changes apply.

## Changes (13 files)

All three Sonnet variants → `claude-opus-4-8`:

- **Bug fix**: `.waxa.yaml` had a malformed `claude-sonnet-4.6` (dots, would 404) → `claude-opus-4-8`
- **Eval/tool config defaults**: `tools/waxa/src/cli.ts` default, `meta/skill-finder`, `meta/skill-selector`, `meta/waxa-eval`, `tooling/nix-setup` eval configs + waxa READMEs/examples (`claude-sonnet-4-6` → `claude-opus-4-8`)
- **Cloudflare AI-gateway docs**: `claude-sonnet-4-5` → `claude-opus-4-8` (left adjacent `openai/gpt-4o` examples untouched — these are multi-provider docs)

## Deliberately left untouched

`claude-opus-4-7` and `claude-haiku-4-5-20251001` in `waxa compare` examples — those illustrate comparing *distinct* models, so collapsing them to one ID would defeat the example.

## Validation

- Edited YAML files still parse.
- No SKILL.md frontmatter `name:` fields touched, so the frontmatter validator is unaffected (`pkf` not available in the build environment).

https://claude.ai/code/session_01EuC1Yy6951oMwx8VmnZ6eG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuC1Yy6951oMwx8VmnZ6eG)_