### PR TITLE
sql-{lint,schema-audit,security}: empirical-tuning Iter 1 fixes

### DIFF
--- a/sql/lint/SKILL.md
+++ b/sql/lint/SKILL.md
@@ -28,13 +28,16 @@ This skill ships **two** linters, with different cost / coverage trade-offs.
 - **select-star**: `SELECT *` (always over-fetch).
 - **double-wildcard-like**: `LIKE '%...%'` (full-table scan risk).
 
-Run:
+Run (this is the default first pass — start here before reaching for sqlfluff):
 
 ```bash
+# `scripts/` is relative to THIS skill's directory. From elsewhere, use the
+# absolute path, e.g. node "$CLAUDE_SKILLS_DIR/sql-lint/scripts/catalog-lint.mjs".
 node scripts/catalog-lint.mjs your-project/db/queries.sql
+echo "exit=$?"   # 0 = clean, 1 = findings — the exit code IS the pass/fail signal
 ```
 
-Exits 0 on clean / 1 on findings. Output is `file:line: [rule] message`, parseable by editor diagnostic gutters.
+Exits 0 on clean / 1 on findings. Output is `file:line: [rule] message`, parseable by editor diagnostic gutters. Note: for `select-star` and `double-wildcard-like`, the reported line is the query's `-- name:` header, not the offending SQL line.
 
 ### Layer 2: sqlfluff (optional, opt-in)
 

--- a/sql/schema-audit/SKILL.md
+++ b/sql/schema-audit/SKILL.md
@@ -19,10 +19,13 @@ Use this for two recurring DBA review tasks:
 ## index-coverage.mjs
 
 ```bash
+# `scripts/` is relative to THIS skill's directory; from elsewhere use the
+# absolute path. `--out` is OPTIONAL — omit it and the report prints to stdout.
+# The printed report IS the deliverable; the file is just a persisted copy.
 node scripts/index-coverage.mjs \
   --schema your-project/db/schema.sql \
   --queries your-project/db/queries.sql \
-  --out your-project/.linters/index-coverage.txt
+  [--out your-project/.linters/index-coverage.txt]
 ```
 
 Output sections:

--- a/sql/security/SKILL.md
+++ b/sql/security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: sql-security
-description: "SQL injection screening for host code (MoonBit / TS / Rust) plus secretlint setup notes. Flags any template-literal or string-concat SQL builder, regardless of value source — the scanner does not trace data flow, so every hit needs a manual review or an explicit `// sql-security: ok` opt-out."
+description: "SQL injection screening for host code (MoonBit / TS / Rust) plus secretlint setup notes. Flags single-line template-literal or string-concat SQL builders, regardless of value source — the scanner is line-based and does NOT trace data flow, so a clean scan is not proof of safety (multi-line template literals are missed) and every hit needs a manual review or an explicit `// sql-security: ok` opt-out."
 version: 0.1.0
 metadata:
   hermes:
@@ -30,6 +30,23 @@ The scanner walks the directory, ignores generated files (`db/gen/`, `sqlc_*.mbt
 The keyword match is **case-sensitive on purpose** — `from` / `where` / `join` appear constantly in English prose and would generate hundreds of false positives if matched case-insensitively.
 
 The scanner exits 1 on findings — every hit deserves a manual review even if it turns out to be safe.
+
+### Limitations — a clean scan is NOT proof of safety
+
+The scanner reads **one line at a time**. Its template-literal rule requires the opening backtick, the `${...}` placeholder, and the closing backtick to all sit on a **single physical line**. Consequences:
+
+- **Multi-line template literals are silently missed.** A query whose backtick opens on one line and whose `${value}` lands on a continuation line (a common formatting style) produces **zero findings and exit 0**, even though it is a genuine injection. Example the scanner does NOT catch:
+
+  ```ts
+  const sql = `
+    SELECT id FROM users
+    WHERE name = ${name}   // <-- real injection, not flagged
+  `;
+  ```
+
+- **Exit 0 means "no single-line hits found," never "safe."** When reviewing for SQL injection, also read any multi-line or programmatically-assembled SQL by hand; do not treat a clean scan as a pass. Fold a multi-line query onto one line if you want the scanner to see it.
+
+This is a deliberate cost/coverage trade-off (zero-dep, no parser), not a bug — but it is a blind spot you must compensate for in review.
 
 ## Reading the findings
 


### PR DESCRIPTION
Empirical prompt-tuning pass (`meta/empirical-prompt-tuning`) over the three sql-* skills tracked in #2, using bias-free subagent executors + two-sided evaluation.

## Method
Iter 0 static check → Iter 1 (7 bias-free executors, median+edge per skill, fixed `[critical]` checklists) → one-theme fix per skill → Iter 2 (fresh executors). Deterministic fixtures; oracle established independently. All scenarios passed at 100% accuracy in **both** iterations with no `tool_uses` skew — these fixes eliminate the qualitative unclear points the executors surfaced.

## Fixes (one theme per skill)
- **sql-lint** — label `catalog-lint` the default first pass; note `scripts/` is skill-relative (+ absolute-path fallback); show exit-code capture (`echo $?`); document that `select-star`/`double-wildcard-like` report the `-- name:` header line, not the offending SQL line.
- **sql-schema-audit** — mark `--out` optional (stdout is the deliverable, the file is just a persisted copy); path note.
- **sql-security** — correct the description's "Flags **any** template-literal" over-claim, and add a **"Limitations — a clean scan is NOT proof of safety"** section: the scanner is line-based, multi-line template literals are silently missed, and exit 0 ≠ safe. *(highest-value fix — a fresh Iter-2 executor reached the correct DO-NOT-SHIP verdict citing the new docs.)*

## Verified by Iter-2 executors
Every Iter-1 unclear point (relative-path/CWD, `--out`-as-required, security coverage over-claim) was resolved and re-confirmed clean by fresh blank-slate executors.

Convergence: resource cutoff / ship-at-80 after Iter 2 per the issue's acceptance clause (one clean iteration post-fix; residual is `node:sqlite` stderr noise only). Full verdict + pattern-ledger posted to #2.

Refs #2.

https://claude.ai/code/session_01EuC1Yy6951oMwx8VmnZ6eG

---
_Generated by [Claude Code](https://claude.ai/code/session_01EuC1Yy6951oMwx8VmnZ6eG)_