### PR TITLE
Add ts2moonbit-migration skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Perspective sub-skills (invoked by `frontend-review-weekly`): `frontend/review-p
 | [moonbit-js-binding](lang/moonbit-js-binding/) | `lang/moonbit-js-binding` | Write MoonBit bindings to JavaScript with `extern "js"` (Promises, opaque types, esm/cjs/iife). |
 | [gleam-practice](lang/gleam-practice/) | `lang/gleam-practice` | Build and review Gleam projects on the Erlang target (Wisp + Mist, OTP, just, CI). |
 | [translate-programming-language](lang/translate-programming-language/) | `lang/translate-programming-language` | Plan and execute language-to-language migrations with behavior parity — oracles, fixtures, parity tests, compatibility layers. |
-| [ts2moonbit-migration](lang/ts2moonbit-migration/) | `lang/ts2moonbit-migration` | Migrate TypeScript to MoonBit on the `js` target while keeping the same JS API contract — using mizchi/js, mizchi/x, mizchi/npm_typed; contract capture, type classification, `.d.ts` diff gate, parity verification. |
+| [ts2moonbit-migration](lang/ts2moonbit-migration/) | `lang/ts2moonbit-migration` | Migrate TypeScript to MoonBit on the `js` target — JS-compatible exported boundary over an idiomatic MoonBit core, using mizchi/js, mizchi/x, mizchi/npm_typed; contract capture, type classification, `.d.ts` diff gate, parity verification. |
 
 ### Testing / Browser
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Perspective sub-skills (invoked by `frontend-review-weekly`): `frontend/review-p
 | [moonbit-js-binding](lang/moonbit-js-binding/) | `lang/moonbit-js-binding` | Write MoonBit bindings to JavaScript with `extern "js"` (Promises, opaque types, esm/cjs/iife). |
 | [gleam-practice](lang/gleam-practice/) | `lang/gleam-practice` | Build and review Gleam projects on the Erlang target (Wisp + Mist, OTP, just, CI). |
 | [translate-programming-language](lang/translate-programming-language/) | `lang/translate-programming-language` | Plan and execute language-to-language migrations with behavior parity — oracles, fixtures, parity tests, compatibility layers. |
+| [ts2moonbit-migration](lang/ts2moonbit-migration/) | `lang/ts2moonbit-migration` | Migrate TypeScript to MoonBit on the `js` target while keeping the same JS API contract — using mizchi/js, mizchi/x, mizchi/npm_typed; contract capture, type classification, `.d.ts` diff gate, parity verification. |
 
 ### Testing / Browser
 

--- a/lang/ts2moonbit-migration/SKILL.md
+++ b/lang/ts2moonbit-migration/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: ts2moonbit-migration
+description: Migrate a TypeScript codebase to MoonBit on the `js` target while keeping the same JavaScript API contract, using mizchi/js (JS/Web/Node bindings), mizchi/x (cross-target async backend: process/fs/http/ws), and mizchi/npm_typed (npm bindings). Use when porting a TS library, Node service, npm package, or Cloudflare Worker to MoonBit and the existing JS/TS consumers, `.d.ts`, and tests must keep working unchanged.
+---
+
+# TypeScript → MoonBit Migration
+
+Port a TypeScript module, library, npm package, or Node service to MoonBit, compile it back to JavaScript with `moon build`, and ship it so existing JS/TS consumers cannot tell the implementation changed. The compiled `.js` + generated `.d.ts` must satisfy the **same API contract** the TypeScript version exposed.
+
+This skill is the playbook that *composes* three lower-level skills — it does not duplicate them:
+
+- **`moonbit-js-binding`** — the mechanics of `extern "js"`, opaque types, Promise bridging, `moon.pkg` exports. Load it when you write FFI by hand.
+- **`translate-programming-language`** — the general parity methodology (oracles, fixtures, shadow testing, cutover). Load it for the verification discipline.
+- **`moonbit-practice`** — MoonBit syntax, tests, `moon` commands.
+
+What this skill adds on top of those: the **mizchi toolkit map**, a **TypeScript-specific type-classification pass**, and the **"preserve the JS API contract" build/publish loop** that lets you swap the implementation without touching downstream code.
+
+## When To Use
+
+Use this skill when **all** of these hold:
+
+- The source is TypeScript (a library, npm package, Node CLI/server, or Worker).
+- The output must remain consumable as JavaScript — same module shape, same exported signatures, ideally the same `.d.ts` and the same test suite.
+- You will build with the MoonBit `js` backend (`moon build`), not WASM-for-the-browser-only.
+
+Do **not** use this skill (reach for the named alternative instead) when:
+
+- You only need to *call* a few JS APIs from an existing MoonBit project → `moonbit-js-binding`.
+- You are migrating between two non-JS languages, or the target is not MoonBit → `translate-programming-language`.
+- You are bundling MoonBit core + a TS entry for Cloudflare → `cloudflare/mbt-worker-bundle` (this skill covers the *porting*, that skill covers the *bundling*).
+
+## The Governing Principle: the contract is the spec
+
+The TypeScript public surface — exported names, parameter/return types, async-ness, error shapes, module format (ESM/CJS) — **is the test oracle**. Capture it first, never improvise it. Every porting decision is judged by one question: *does a consumer importing the built `.js` still see the same thing?*
+
+Concretely, before porting a single function:
+
+1. Inventory the exported symbols and their `.d.ts` signatures (`references/contract-capture.md`).
+2. Snapshot the existing test suite — it becomes the parity gate, run against the MoonBit-built artifact.
+3. Decide the contract level per export: **byte-exact** (serializers, hashers), **structural** (objects/JSON), or **semantic** (a value that round-trips). Most exports are structural.
+
+## The mizchi Toolkit Map
+
+Pick the binding layer by *surface*, not by habit. Full install lines and import paths are in `references/toolkit-map.md`.
+
+| Source TypeScript uses… | MoonBit package | `moon add` |
+|---|---|---|
+| JS built-ins, Web Standard APIs, `node:*` built-ins | `mizchi/js` | `moon add mizchi/js` |
+| DOM, canvas, IndexedDB, storage, service workers | `mizchi/js_browser` | `moon add mizchi/js_browser` |
+| Deno / Bun runtime APIs | `mizchi/js_deno`, `mizchi/js_bun` | per runtime |
+| npm packages (React, Hono, Zod, AI SDK, Drizzle…) | `mizchi/npm_typed` | `moon add mizchi/npm_typed` |
+| Node backend I/O that must run on **both** native and js (spawn, fs, http server, ws, tcp/tls) | `mizchi/x` | `moon add mizchi/x` |
+| Cloudflare Workers runtime | `mizchi/cloudflare` | `moon add mizchi/cloudflare` |
+
+Rules of thumb:
+
+- **Reach for a binding before writing FFI.** Hand-rolled `extern "js"` is a last resort for APIs no package covers. When you do write it, follow `moonbit-js-binding`.
+- **`mizchi/js` is the `any`-friendly layer.** Its `Any` type + zero-cost casts (`any(x)`, `Any::cast`, `obj["key"]`, method `_call`) mirror TypeScript's `any` and let you make progress before every type is nailed down. Tighten types as you go.
+- **`mizchi/x` is the cross-target backend.** If the TS service does process/fs/http/websocket work and you want it to also run on `--target native` later, port onto `mizchi/x` (which delegates to `moonbitlang/async` natively and to JS FFI on the js target) instead of binding `node:*` directly.
+
+## Workflow
+
+Eight phases. Do not skip Phase 0 — porting without the captured contract is how you ship a silent behavior change.
+
+### Phase 0 — Capture the contract
+Read `references/contract-capture.md`.
+- Enumerate every exported symbol and its type signature (from `.d.ts`, `tsc --declaration`, or `package.json` `exports`).
+- Pin the source runtime; freeze the existing test suite as the oracle. Generate fixtures from the TS implementation for ordinary, boundary, malformed, and error cases — never hand-author expected values.
+- Record the module format(s) the package ships (`esm`, `cjs`, dual) and the entry points in `package.json`.
+
+### Phase 1 — Project setup
+- `moon.mod.json`: set `"preferred-target": "js"` so `moon check/build/test` default to JS.
+- `moon add` the toolkit packages you mapped in Phase 0.
+- Lay out `src/moon.pkg` with `link.js` (exports + format) — empty exports for now, filled in Phase 6.
+- Decide the npm interop shape: a thin `package.json` whose `exports` point at the `moon build --release` output (see `references/build-and-publish.md`).
+
+### Phase 2 — Classify types
+Read `references/type-mapping.md`.
+This is the TypeScript analog of the OCaml `string`-vs-`Bytes` hazard. Classify **every** field and parameter by *meaning* before choosing a MoonBit type:
+- `number` → `Int`/`Double` *only if* `|x| < 2^53`; anything that can exceed it (ids, timestamps-as-int, bitfields) → `BigInt`/`Int64`, and check the contract for which the JS side expects.
+- `string` carrying bytes (base64-decoded, binary protocols) → `Bytes`, not `String`.
+- `T | null | undefined` unions → do **not** collapse to `T?`; split with `is_null`/`is_undefined`.
+- Object/record literals, discriminated unions, `Date`, `Promise<T>`, callbacks — see the reference table.
+
+### Phase 3 — Port leaf modules
+- Port pure/leaf modules first, then shared helpers, then I/O adapters, then orchestration/entry.
+- Use `mizchi/js` (`Any`, builtins) for JS-value interaction; keep raw FFI behind safe typed wrappers.
+- Co-locate a MoonBit test per ported slice; assert against the Phase 0 fixtures.
+
+### Phase 4 — Port backend / async I/O
+- Map `Promise<T>` to MoonBit `async fn` + `.wait()` (Promise bridging — `moonbit-js-binding`).
+- For process/fs/http/ws/tcp, port onto `mizchi/x` so the same source runs on native and js. Add `moonbitlang/async` (`for "test"`) for `async test`.
+
+### Phase 5 — Port npm dependencies
+- Replace each npm import with its `mizchi/npm_typed` binding where one exists.
+- For an npm package with no binding: write a minimal `extern "js"` + `#module("pkg")` wrapper (named-export rules in `moonbit-js-binding`), exposing only the surface you actually call. Don't bind the whole library.
+
+### Phase 6 — Re-export to satisfy the contract
+Read `references/build-and-publish.md`.
+- List the Phase 0 export names in `link.js.exports` (use `"moonbit_name:js_name"` to match the original casing/naming).
+- Set `link.js.format` to match what the package shipped (`esm`/`cjs`; dual-build if the original was dual).
+- `moon build --release`; diff the **generated `.d.ts`** against the Phase 0 `.d.ts`. Reconcile every difference — a changed signature is a broken contract. Watch the leak-prone shapes: `Int64`→`bigint`, enums-with-data, trait objects (see `references/type-mapping.md`).
+
+### Phase 7 — Verify parity and cut over
+Read `references/parity-verification.md` (and `translate-programming-language` for the full gate discipline).
+- Point the **original TypeScript test suite** at the MoonBit-built `.js` and run it. Green here is the primary signal.
+- For services, shadow/replay real traffic and diff responses, headers, and side effects before switching.
+- Canary with a rollback window; keep the TS implementation deployable until the window closes.
+
+## Type Mapping (quick reference)
+
+Full table with edge cases in `references/type-mapping.md`.
+
+| TypeScript | MoonBit (with mizchi/js) | Watch out for |
+|---|---|---|
+| `boolean` | `Bool` | — |
+| `number` (int, `< 2^53`) | `Int` / `UInt` | beyond 2^53 → `BigInt` |
+| `number` (float) | `Double` | — |
+| `bigint` | `BigInt` / `Int64` | `Int64` surfaces as `bigint` in `.d.ts` |
+| `string` (text) | `String` | UTF-16 length, not bytes |
+| `string` (binary) | `Bytes` | classify by meaning |
+| `Uint8Array` | `Bytes` | no-copy |
+| `T[]` | `Array[T]` | — |
+| `any` / `unknown` | `Any` (mizchi/js) | cast with `Any::cast` |
+| `object` / record | `struct` | don't pass `Map`/trait objects across the boundary |
+| discriminated union | `enum` | data-carrying enums are awkward from JS; prefer constructor fns |
+| `T \| undefined` | `T?` via `is_undefined` | — |
+| `T \| null` | `Nullable[T]` wrapper | `null ≠ undefined` |
+| `Promise<T>` | `async fn` + `.wait()` | exported async needs `run_async` |
+| `(…) => R` callback | `FuncRef`/closure | — |
+| `Date` | `mizchi/js` `Date` binding | — |
+
+## Decision Table
+
+| Situation | Do this |
+|---|---|
+| Need to call a JS/Web/Node built-in | `mizchi/js` binding; FFI only if missing |
+| Need DOM / browser API | `mizchi/js_browser` |
+| Need an npm package | `mizchi/npm_typed`; else minimal `#module()` wrapper |
+| Backend I/O that should also run native | `mizchi/x` (not raw `node:*`) |
+| Value can exceed 2^53 | `BigInt`/`Int64`, confirm against contract |
+| `string` is actually bytes | `Bytes` |
+| Union with both `null` and `undefined` | split, don't use `T?` alone |
+| Exported function is async | `async fn` + `run_async` at the export; `.d.ts` shows `Promise<T>` |
+| Original package was dual ESM/CJS | dual-build; match `package.json` `exports` |
+| `.d.ts` signature changed after build | contract break — fix the MoonBit signature, don't patch the `.d.ts` |
+| Unsure a behavior matches | run the original TS test against the built `.js` |
+
+## Common Pitfalls
+
+1. **Porting before capturing the contract.** Without the Phase 0 `.d.ts` + test snapshot you have no parity oracle and will ship silent changes.
+2. **`number` → `Int` reflex.** JS `number` is IEEE-754. Ids, epoch-millis-as-int, and bitmasks overflow `Int` semantics or lose precision past 2^53. Classify first.
+3. **Collapsing `T | null | undefined` into `T?`.** `Some(null)` is nonsense; the contract distinguishes the two. Split with `is_null`/`is_undefined`.
+4. **Binding `node:*` directly when you wanted cross-target.** If the service should later run native, port onto `mizchi/x`, not hand-rolled `node:fs`/`node:http` FFI.
+5. **Leaking MoonBit internals in the `.d.ts`.** Passing `Map`, `Result`, data-carrying `enum`, or trait objects across the boundary emits MoonBit's internal runtime shape into the `.d.ts`. Expose plain structs / opaque `#external` types / pairs of constructor functions.
+6. **Wrong `link.js.format`.** Shipping ESM where the package was CJS (or vice-versa) breaks every consumer even if signatures match. Match Phase 0; dual-build if the original was dual.
+7. **Forgetting `run_async` on an exported async fn.** An exported MoonBit sync function can't `await`; wrap with `run_async` so JS receives a real `Promise`.
+8. **Binding the whole npm library.** Bind only the surface you call. Over-binding wastes effort and bloats output.
+9. **Trusting unit parity alone.** Run the *original* TS suite against the built artifact and shadow real traffic before cutover (`translate-programming-language` gates).
+
+## References
+
+@references/contract-capture.md
+@references/toolkit-map.md
+@references/type-mapping.md
+@references/build-and-publish.md
+@references/parity-verification.md

--- a/lang/ts2moonbit-migration/SKILL.md
+++ b/lang/ts2moonbit-migration/SKILL.md
@@ -39,6 +39,15 @@ Concretely, before porting a single function:
 2. Snapshot the existing test suite — it becomes the parity gate, run against the MoonBit-built artifact.
 3. Decide the contract level per export: **byte-exact** (serializers, hashers), **structural** (objects/JSON), or **semantic** (a value that round-trips). Most exports are structural.
 
+## Architecture: JS-compatible boundary, idiomatic MoonBit core
+
+The contract governs **only the exported boundary**. Behind it, write the implementation as clean, idiomatic MoonBit — the code you'd be happy to show a MoonBit reviewer, not a transliteration of the TypeScript. Two layers, kept separate (details + verified example in `references/boundary-and-core.md`):
+
+- **Boundary adapter** (one thin file per exported surface, gated `["js"]`): the *only* place `@core.Any`, `_get`/`_set`/`cast`, `throw_error`, and `promisify*` appear. It parses JS values into core types, delegates, and marshals results back into the JS shapes the contract demands. It contains no business logic.
+- **Idiomatic core**: rich `enum` + `match`, `struct`, `Result`/`raise`, `Map`, `Option`, generics. **No JS types reach this layer.** It is backend-agnostic and tested directly against the Phase 0 fixtures (no Node round-trip).
+
+If `Any` or `_get`/`throw_error` shows up in a core module, the abstraction leaked — push it back out to the adapter. `Any` is a *bootstrapping and boundary* tool, never the destination: use it to get the port compiling, then pull the logic down into typed core modules. The boundary signatures are frozen by the contract; the core types are yours to refactor freely once parity holds.
+
 ## The mizchi Toolkit Map
 
 Pick the binding layer by *surface*, not by habit. Full install lines and import paths are in `references/toolkit-map.md`.
@@ -55,7 +64,7 @@ Pick the binding layer by *surface*, not by habit. Full install lines and import
 Rules of thumb:
 
 - **Reach for a binding before writing FFI.** Hand-rolled `extern "js"` is a last resort for APIs no package covers. When you do write it, follow `moonbit-js-binding`.
-- **`mizchi/js` is the `any`-friendly layer.** Its `Any` type + zero-cost casts (`any(x)`, `Any::cast`, property access `_get`/`_set`, method `_call`/`_invoke`) mirror TypeScript's `any` and let you make progress before every type is nailed down. Tighten types as you go.
+- **`mizchi/js`'s `Any` is a boundary tool, not the destination.** Its `Any` type + zero-cost casts (`any(x)`, `Any::cast`, property access `_get`/`_set`, method `_call`/`_invoke`) mirror TypeScript's `any` and let you get the port compiling. Keep them in the boundary adapter and replace them with typed core code as you go (see the Architecture section).
 - **`mizchi/x` is the cross-target backend.** If the TS service does process/fs/http/websocket work and you want it to also run on `--target native` later, port onto `mizchi/x` (which delegates to `moonbitlang/async` natively and to JS FFI on the js target) instead of binding `node:*` directly.
 
 ## Workflow
@@ -82,10 +91,11 @@ This is the TypeScript analog of the OCaml `string`-vs-`Bytes` hazard. Classify 
 - `T | null | undefined` unions → do **not** collapse to `T?`; split with `is_null`/`is_undefined`.
 - Object/record literals, discriminated unions, `Date`, `Promise<T>`, callbacks — see the reference table.
 
-### Phase 3 — Port leaf modules
+### Phase 3 — Port leaf modules (idiomatic core + thin adapter)
+Read `references/boundary-and-core.md`.
 - Port pure/leaf modules first, then shared helpers, then I/O adapters, then orchestration/entry.
-- Use `mizchi/js` (`Any`, builtins) for JS-value interaction; keep raw FFI behind safe typed wrappers.
-- Co-locate a MoonBit test per ported slice; assert against the Phase 0 fixtures.
+- Write the logic as **idiomatic MoonBit core** (`enum`/`match`, `struct`, `Result`/`raise`) with no JS types; keep `Any`/`_get`/`throw_error`/FFI confined to a **thin boundary adapter** file per exported surface.
+- Test the core directly against the Phase 0 fixtures (no Node round-trip needed); test the adapter through Node to confirm the contract.
 
 ### Phase 4 — Port backend / async I/O
 - Map `Promise<T>` to MoonBit `async fn` + `.wait()` (Promise bridging — `moonbit-js-binding`).
@@ -166,6 +176,7 @@ The build/export/FFI workflow and the `mizchi/js` `Any` API in this skill were v
 
 @references/contract-capture.md
 @references/toolkit-map.md
+@references/boundary-and-core.md
 @references/type-mapping.md
 @references/build-and-publish.md
 @references/parity-verification.md

--- a/lang/ts2moonbit-migration/SKILL.md
+++ b/lang/ts2moonbit-migration/SKILL.md
@@ -48,6 +48,21 @@ The contract governs **only the exported boundary**. Behind it, write the implem
 
 If `Any` or `_get`/`throw_error` shows up in a core module, the abstraction leaked — push it back out to the adapter. `Any` is a *bootstrapping and boundary* tool, never the destination: use it to get the port compiling, then pull the logic down into typed core modules. The boundary signatures are frozen by the contract; the core types are yours to refactor freely once parity holds.
 
+## Before You Port: Library Triage
+
+When the thing you're replacing is a *library*, run two checks before Phase 0 — they decide whether and how to port.
+
+**1. Does the library's reason-to-exist survive in MoonBit?** Many JS libraries exist to paper over a JS gap that MoonBit doesn't have (ergonomic immutable updates, structural deep-equal, tiny typed utilities). For a **MoonBit consumer**, the right move is often to *not port the library* and use the native idiom instead. Porting is justified when **existing JS consumers** must keep importing the same module — then you reproduce the contract even if MoonBit wouldn't need the library internally.
+
+**2. Classify the library — it predicts how much idiomatic core you'll get:**
+
+| Class | What it is | Port shape | Example (verified) |
+|---|---|---|---|
+| **Domain-logic** | parsing, algorithms, data transforms, validation | rich idiomatic core (`enum`/`match`/`struct`) + thin boundary — the Architecture pattern shines | **semver**: `enum Ident` / `struct SemVer` core + `match`-based precedence; 198/198 parity vs `semver@7.8.1` |
+| **Runtime-mechanics** | Proxy / getter-setter / prototype tricks, reflection, JS-engine behaviors | little-to-no idiomatic core; stays FFI-heavy in `extern "js"`. Consider whether to port at all | **immer**: Proxy copy-on-write in FFI; 12/12 contract parity (incl. structural sharing) vs `immer@10` — but no idiomatic core, and MoonBit needs no immer (`{ ..base, x: v }` is native) |
+
+If the library is runtime-mechanics **and** the consumer could be MoonBit, prefer exposing the native idiom over porting. If it's domain-logic, expect a clean core and proceed to Phase 0.
+
 ## The mizchi Toolkit Map
 
 Pick the binding layer by *surface*, not by habit. Full install lines and import paths are in `references/toolkit-map.md`.

--- a/lang/ts2moonbit-migration/SKILL.md
+++ b/lang/ts2moonbit-migration/SKILL.md
@@ -55,7 +55,7 @@ Pick the binding layer by *surface*, not by habit. Full install lines and import
 Rules of thumb:
 
 - **Reach for a binding before writing FFI.** Hand-rolled `extern "js"` is a last resort for APIs no package covers. When you do write it, follow `moonbit-js-binding`.
-- **`mizchi/js` is the `any`-friendly layer.** Its `Any` type + zero-cost casts (`any(x)`, `Any::cast`, `obj["key"]`, method `_call`) mirror TypeScript's `any` and let you make progress before every type is nailed down. Tighten types as you go.
+- **`mizchi/js` is the `any`-friendly layer.** Its `Any` type + zero-cost casts (`any(x)`, `Any::cast`, property access `_get`/`_set`, method `_call`/`_invoke`) mirror TypeScript's `any` and let you make progress before every type is nailed down. Tighten types as you go.
 - **`mizchi/x` is the cross-target backend.** If the TS service does process/fs/http/websocket work and you want it to also run on `--target native` later, port onto `mizchi/x` (which delegates to `moonbitlang/async` natively and to JS FFI on the js target) instead of binding `node:*` directly.
 
 ## Workflow
@@ -126,7 +126,7 @@ Full table with edge cases in `references/type-mapping.md`.
 | discriminated union | `enum` | data-carrying enums are awkward from JS; prefer constructor fns |
 | `T \| undefined` | `T?` via `is_undefined` | — |
 | `T \| null` | `Nullable[T]` wrapper | `null ≠ undefined` |
-| `Promise<T>` | `async fn` + `.wait()` | exported async needs `run_async` |
+| `Promise<T>` | `async fn` + `.wait()`; export via `@core.promisify*` | exported async surfaces as `any` in `.d.ts`, not `Promise<T>` |
 | `(…) => R` callback | `FuncRef`/closure | — |
 | `Date` | `mizchi/js` `Date` binding | — |
 
@@ -141,7 +141,7 @@ Full table with edge cases in `references/type-mapping.md`.
 | Value can exceed 2^53 | `BigInt`/`Int64`, confirm against contract |
 | `string` is actually bytes | `Bytes` |
 | Union with both `null` and `undefined` | split, don't use `T?` alone |
-| Exported function is async | `async fn` + `run_async` at the export; `.d.ts` shows `Promise<T>` |
+| Exported function is async | return `@core.Promise[T]` via `@core.promisify*`/`from_async`; JS receives a real `Promise` (`.d.ts` type is `any`) |
 | Original package was dual ESM/CJS | dual-build; match `package.json` `exports` |
 | `.d.ts` signature changed after build | contract break — fix the MoonBit signature, don't patch the `.d.ts` |
 | Unsure a behavior matches | run the original TS test against the built `.js` |
@@ -154,9 +154,13 @@ Full table with edge cases in `references/type-mapping.md`.
 4. **Binding `node:*` directly when you wanted cross-target.** If the service should later run native, port onto `mizchi/x`, not hand-rolled `node:fs`/`node:http` FFI.
 5. **Leaking MoonBit internals in the `.d.ts`.** Passing `Map`, `Result`, data-carrying `enum`, or trait objects across the boundary emits MoonBit's internal runtime shape into the `.d.ts`. Expose plain structs / opaque `#external` types / pairs of constructor functions.
 6. **Wrong `link.js.format`.** Shipping ESM where the package was CJS (or vice-versa) breaks every consumer even if signatures match. Match Phase 0; dual-build if the original was dual.
-7. **Forgetting `run_async` on an exported async fn.** An exported MoonBit sync function can't `await`; wrap with `run_async` so JS receives a real `Promise`.
+7. **Exporting a raw `async fn`.** A sync JS caller can't `await` a bare MoonBit `async fn`. Wrap the internal async logic with `@core.promisify*` (or `from_async`) so the export returns `@core.Promise[T]` and JS receives a real `Promise`. Note the generated `.d.ts` types it as `any`, not `Promise<T>`.
 8. **Binding the whole npm library.** Bind only the surface you call. Over-binding wastes effort and bloats output.
 9. **Trusting unit parity alone.** Run the *original* TS suite against the built artifact and shadow real traffic before cutover (`translate-programming-language` gates).
+
+## Verified Against
+
+The build/export/FFI workflow and the `mizchi/js` `Any` API in this skill were verified end-to-end with **moon 0.1.20260522 / moonc v0.9.3** and **mizchi/js 0.12.1** (round-tripping objects and Promises through Node). Package boundaries and the `Any` method names (`_get`/`_set`/`_call`/`cast`) shift across releases — re-check against the resolved version in your `moon.mod.json` if a signature mismatches.
 
 ## References
 

--- a/lang/ts2moonbit-migration/references/boundary-and-core.md
+++ b/lang/ts2moonbit-migration/references/boundary-and-core.md
@@ -106,3 +106,12 @@ shape_area({ kind: "tri", a: 1 });        // throws Error: unknown shape: tri
 - **Test the core directly** with ordinary MoonBit tests against the Phase 0 fixtures — no JS round-trip needed. Test the *adapter* through Node to confirm the contract.
 - **Keep the adapter dumb.** It marshals and delegates; it contains no business logic. If you're tempted to put a branch of real logic in the adapter, it belongs in the core.
 - **Refactor the core freely** once parity holds — its types are yours, not the contract's. Only the boundary signatures are frozen.
+
+## Worked examples (verified against the real npm packages)
+
+Two ports, run through this skill end-to-end, illustrate the two library classes from the triage step:
+
+- **semver (domain-logic → idiomatic core).** Core is `enum Ident { Num(Int); Alpha(String) }` + `struct SemVer` + a `match`-based `compare` implementing spec precedence; the boundary marshals `String`/`Any` only. **198/198** parity vs `semver@7.8.1` (full precedence chain, parse, valid, gt/lt/eq). Two lessons it surfaced, both now in the references:
+  - MoonBit `String` `<` orders by length, not lexicographically → prerelease comparison needed an explicit code-unit routine (`type-mapping.md`).
+  - The core method `SemVer::parse` collided with the exported boundary `parse`, producing a duplicate JS export → renamed the core method to `from_string` (`build-and-publish.md`).
+- **immer (runtime-mechanics → FFI wrapper).** Proxy copy-on-write lives entirely in an `extern "js"` body; the MoonBit layer is a thin `produce(base, recipe)` pass-through. **12/12** contract parity vs `immer@10`, including structural sharing (untouched subtrees keep referential identity) and recipe-return. There is essentially no idiomatic core to extract — and a MoonBit consumer wouldn't use immer at all, since `{ ..base, field: v }` is native. This is the triage signal that a library is runtime-mechanics: the port is correct but FFI-shaped, with nothing to pull down into typed core.

--- a/lang/ts2moonbit-migration/references/boundary-and-core.md
+++ b/lang/ts2moonbit-migration/references/boundary-and-core.md
@@ -1,0 +1,108 @@
+# Boundary Adapter + Idiomatic Core
+
+The project policy: **the externally exported interface conforms to the JS contract, but the implementation behind it is idiomatic MoonBit.** Keep a thin adapter layer at the boundary and a clean core that never sees a JS type. This is the anti-corruption layer / ports-and-adapters pattern applied to migration.
+
+## The two layers
+
+```
+JS / TS consumers
+      │  (the captured contract: names, shapes, formats, errors)
+┌─────▼───────────────────────────────────────┐
+│  Boundary adapter  (one thin file per export)│  ← Any, plain structs, Int/Double,
+│  - parse JS values into core types           │    _get/_set/cast, throw_error,
+│  - call the core                             │    promisify — JS-shaped in/out
+│  - convert core results back to JS shapes    │
+├──────────────────────────────────────────────┤
+│  Idiomatic MoonBit core                       │  ← enum + match, struct, Result/raise,
+│  - rich types, pattern matching, no JS types  │    Map, Option, generics. NO @core.Any,
+│  - the part you'd be proud to show a MoonBit  │    NO _get/_set, NO throw_error here.
+│    reviewer                                   │
+└───────────────────────────────────────────────┘
+```
+
+**Rule of thumb:** `@core.Any`, `_get`/`_set`/`cast`, `throw_error`, and `promisify*` live *only* in boundary files. If one appears in a core module, the abstraction has leaked — push it out to the adapter.
+
+## Verified example
+
+Idiomatic core — rich `enum`, `match`, typed error. No JS types:
+
+```mbt nocheck
+// core_shape.mbt
+pub enum Shape {
+  Circle(Double)
+  Rect(Double, Double)
+}
+
+pub fn Shape::area(self : Shape) -> Double {
+  match self {
+    Circle(r) => 3.141592653589793 * r * r
+    Rect(w, h) => w * h
+  }
+}
+
+pub suberror ShapeError { ShapeError(String) }
+
+pub fn Shape::parse(
+  kind : String, a : Double, b : Double,
+) -> Shape raise ShapeError {
+  match kind {
+    "circle" => Circle(a)
+    "rect" => Rect(a, b)
+    _ => raise ShapeError("unknown shape: " + kind)
+  }
+}
+```
+
+Thin boundary adapter — the only file that touches JS. Parses the JS object into the core enum, calls the idiomatic method, maps the typed error onto a JS `throw`:
+
+```mbt nocheck
+// boundary_shape.mbt  (gate to ["js"] in moon.pkg)
+pub fn shape_area(input : @core.Any) -> Double {
+  let kind : String = input._get("kind").cast()
+  let a : Double = input._get("a").cast()
+  let b : Double = if @core.is_undefined(input._get("b")) {
+    0.0
+  } else {
+    input._get("b").cast()
+  }
+  match (try? Shape::parse(kind, a, b)) {
+    Ok(shape) => shape.area()        // idiomatic core does the real work
+    Err(ShapeError(msg)) => {
+      @core.throw_error(msg)         // typed error -> JS Error, matches contract
+      0.0
+    }
+  }
+}
+```
+
+From JS the contract is plain and idiomatic-JS:
+
+```js
+shape_area({ kind: "circle", a: 2 });   // 12.566...
+shape_area({ kind: "rect", a: 3, b: 4 }); // 12
+shape_area({ kind: "tri", a: 1 });        // throws Error: unknown shape: tri
+```
+
+(Verified end-to-end with moon 0.1.x / mizchi/js 0.12.1.)
+
+## What goes where
+
+| Concern | Idiomatic core | Boundary adapter |
+|---|---|---|
+| Domain types | `enum`, `struct`, generics, `Map`, `Option` | plain `struct` / `Any` mirroring the JS shape |
+| Errors | `suberror` + `raise` / `Result` | `throw_error` (if contract throws) or a `{ok,error}` struct (if it returns) |
+| Numbers | the right type (`Int`, `Double`, `BigInt`) for the domain | whatever the contract's `number`/`bigint` is; convert at the edge |
+| Async | `async fn` + `.wait()` | wrap with `@core.promisify*` to return `@core.Promise[T]` |
+| Nullability | `Option`, real sum types | `is_nullish`/`nullable`/`from_option` against JS `null`/`undefined` |
+| Collections | `Array`, `Map`, views | `Array[(String, V)]` / `Any` object — never pass `Map`/trait objects out |
+
+## Why not "just use Any everywhere"
+
+`Any` is a fine *bootstrapping* and *boundary* tool, but as a destination it throws away everything MoonBit is good at — exhaustive `match`, type safety, refactorability — and produces code no better than the TypeScript you left. Use `Any` to get the port compiling, then pull the logic down into typed core modules and leave only the marshalling at the boundary.
+
+## Practical tips
+
+- **One adapter file per exported surface**, gated `["js"]` in `moon.pkg`. The core files stay backend-agnostic (and can even be tested on `--target native` if they have no JS dependency).
+- **Test the core directly** with ordinary MoonBit tests against the Phase 0 fixtures — no JS round-trip needed. Test the *adapter* through Node to confirm the contract.
+- **Keep the adapter dumb.** It marshals and delegates; it contains no business logic. If you're tempted to put a branch of real logic in the adapter, it belongs in the core.
+- **Refactor the core freely** once parity holds — its types are yours, not the contract's. Only the boundary signatures are frozen.

--- a/lang/ts2moonbit-migration/references/build-and-publish.md
+++ b/lang/ts2moonbit-migration/references/build-and-publish.md
@@ -1,0 +1,125 @@
+# Build & Publish: satisfying the JS API contract
+
+The goal of Phase 6: produce a `.js` + `.d.ts` that a consumer importing the package cannot distinguish from the TypeScript original. The build configuration *is* the contract enforcement.
+
+## moon.mod.json
+
+```json
+{
+  "name": "you/pkg",
+  "version": "0.1.0",
+  "source": "src",
+  "preferred-target": "js"
+}
+```
+
+`preferred-target: "js"` makes `moon check`/`build`/`test` default to the JS backend. It's a default, not a lock — `moon test --target native` still works for code that supports it (relevant when porting onto `mizchi/x`).
+
+## src/moon.pkg — exports + format
+
+```
+import {
+  "mizchi/js/core",
+  "mizchi/js",
+  "moonbitlang/async" for "test",
+}
+
+options(
+  link: {
+    "js": {
+      "exports": ["create_app:createApp", "parse", "stringify"],
+      "format": "esm",
+    },
+  },
+)
+```
+
+- **`exports`** must list every Phase 0 export name. Use `"moonbit_name:js_name"` to match the original casing — MoonBit is `snake_case`, the JS contract is usually `camelCase`. `create_app:createApp` exports MoonBit `create_app` as JS `createApp`.
+- **`format`** must match what the package shipped (`esm` / `cjs` / `iife`). Wrong format breaks consumers even when signatures match.
+- Gate any file containing `extern "js"` to `["js"]` via `targets:` (see `moonbit-js-binding`).
+
+> Use the `moon.pkg` DSL form (no `.json`). Do not mix with `moon.pkg.json`.
+
+## Async exports — return a real Promise
+
+An exported MoonBit `async fn` cannot be awaited by a sync JS caller as-is. Wrap so JS receives a `Promise<T>` and the `.d.ts` shows `Promise<T>`:
+
+```mbt nocheck
+// internal async logic
+async fn do_work_impl(x : Int) -> Int { ... }
+
+// exported boundary: kick off async from sync, hand JS a Promise
+pub fn do_work(x : Int) -> Promise[Int] {
+  // run_async / %async.run schedules the body; resolve into a Promise
+  // (full pattern in moonbit-js-binding: promise-bridging.md)
+  ...
+}
+```
+
+List `do_work` in `exports`; the generated `.d.ts` will read `export function doWork(x: number): Promise<number>`.
+
+## Build
+
+```bash
+moon check                 # fast type-check
+moon test                  # run MoonBit tests (js default)
+moon build --release       # publishable artifact + .d.ts
+```
+
+Release output:
+
+```
+_build/js/release/build/
+├── <pkg>.js        # ESM/CJS/IIFE per link.js.format
+├── <pkg>.js.map
+├── <pkg>.d.ts      # generated TypeScript declarations
+└── moonbit.d.ts    # MoonBit primitive aliases (Int→number, String→string, …)
+```
+
+## The `.d.ts` diff gate
+
+This is the hard contract check. Diff the generated declaration against the Phase 0 snapshot:
+
+```bash
+moon build --release
+diff <(npx tsc --noEmit false /dev/null 2>/dev/null; cat contract/index.d.ts) \
+     _build/js/release/build/<pkg>.d.ts
+# or simply eyeball both files side by side
+```
+
+Every difference is either a contract break to fix in MoonBit, or an intentional, documented change. Common offenders and fixes:
+
+| `.d.ts` shows | Means | Fix |
+|---|---|---|
+| `bigint` where contract has `number` | you used `Int64`/`BigInt` | switch to `Int`/`Double` if the value fits, or document the change |
+| tagged-object type | data-carrying `enum` at boundary | replace with struct or constructor fns |
+| `MoonBit`-prefixed internal type | leaked `Map`/`Result`/trait object | convert to plain struct / `Any` |
+| missing export | name not in `link.js.exports` | add it |
+| wrong export name | snake_case leaked | use `"snake:camel"` rename |
+
+## npm packaging
+
+Wrap the release output so consumers `import` it normally. Minimal `package.json`:
+
+```json
+{
+  "name": "your-pkg",
+  "version": "0.1.0",
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./_build/js/release/build/pkg.d.ts",
+      "import": "./_build/js/release/build/pkg.js"
+    }
+  },
+  "files": ["_build/js/release/build"]
+}
+```
+
+Match the **original** `package.json` `exports` map (entry names, conditions). If the source was dual ESM+CJS, build both formats (two packages or two `link` configs) and provide `import`/`require` conditions accordingly.
+
+For app/bundler integration, `mizchi/vite-plugin-moonbit` compiles `.mbt` on the fly so you can `import` MoonBit modules directly during development without a manual `moon build` step.
+
+## Source maps
+
+`.js.map` is emitted by default. For obfuscated production output use `moon build --release --no-source-map`, or point your bundler at the maps for debuggable builds.

--- a/lang/ts2moonbit-migration/references/build-and-publish.md
+++ b/lang/ts2moonbit-migration/references/build-and-publish.md
@@ -98,6 +98,7 @@ Every difference is either a contract break to fix in MoonBit, or an intentional
 | `MoonBit`-prefixed internal type | leaked `Map`/`Result`/trait object | convert to plain struct / `Any` |
 | missing export | name not in `link.js.exports` | add it |
 | wrong export name | snake_case leaked | use `"snake:camel"` rename |
+| duplicate export (Node fails to load: `Duplicate export`) | an `exports` entry resolves to *both* a free `fn` and a same-named static method (e.g. `parse` matches boundary `parse` **and** `SemVer::parse`) | give the core method a distinct identifier (`SemVer::from_string`, `SemVer::cmp`) so only the boundary owns the exported name |
 
 ## npm packaging
 

--- a/lang/ts2moonbit-migration/references/build-and-publish.md
+++ b/lang/ts2moonbit-migration/references/build-and-publish.md
@@ -25,6 +25,7 @@ import {
 }
 
 options(
+  supported_targets: "js",   // app/leaf: silences the mizchi/js supported_targets warning
   link: {
     "js": {
       "exports": ["create_app:createApp", "parse", "stringify"],
@@ -42,21 +43,22 @@ options(
 
 ## Async exports — return a real Promise
 
-An exported MoonBit `async fn` cannot be awaited by a sync JS caller as-is. Wrap so JS receives a `Promise<T>` and the `.d.ts` shows `Promise<T>`:
+An exported MoonBit `async fn` cannot be awaited by a sync JS caller as-is. Wrap the internal async logic with `mizchi/js/core`'s `promisify*` (or `from_async`) so the export returns `@core.Promise[T]` and JS receives a real `Promise`. Verified pattern (mizchi/js 0.12.1):
 
 ```mbt nocheck
 // internal async logic
-async fn do_work_impl(x : Int) -> Int { ... }
+async fn do_work_impl(x : Int) -> Int {
+  @core.sleep(1)
+  x * 2
+}
 
-// exported boundary: kick off async from sync, hand JS a Promise
-pub fn do_work(x : Int) -> Promise[Int] {
-  // run_async / %async.run schedules the body; resolve into a Promise
-  // (full pattern in moonbit-js-binding: promise-bridging.md)
-  ...
+// exported boundary: hand JS a real Promise
+pub fn do_work(x : Int) -> @core.Promise[Int] {
+  (@core.promisify1(do_work_impl))(x)
 }
 ```
 
-List `do_work` in `exports`; the generated `.d.ts` will read `export function doWork(x: number): Promise<number>`.
+List `do_work` in `exports`. At runtime JS gets a genuine `Promise` (`p instanceof Promise === true`, `await p` works — verified). **But** the generated `.d.ts` types the return as `any`, not `Promise<number>`, because `@core.Promise[T]` is an external type. If consumers need the precise `Promise<T>` type, ship a small hand-maintained overlay `.d.ts` that re-declares the async exports, or wrap the package in a thin typed `index.ts`.
 
 ## Build
 
@@ -82,9 +84,9 @@ This is the hard contract check. Diff the generated declaration against the Phas
 
 ```bash
 moon build --release
-diff <(npx tsc --noEmit false /dev/null 2>/dev/null; cat contract/index.d.ts) \
-     _build/js/release/build/<pkg>.d.ts
-# or simply eyeball both files side by side
+diff contract/index.d.ts _build/js/release/build/<pkg>.d.ts
+# names/casing won't line up 1:1 (snake_case, MoonBit.* aliases) — read it,
+# don't expect a clean diff. The point is to catch type/shape regressions.
 ```
 
 Every difference is either a contract break to fix in MoonBit, or an intentional, documented change. Common offenders and fixes:

--- a/lang/ts2moonbit-migration/references/contract-capture.md
+++ b/lang/ts2moonbit-migration/references/contract-capture.md
@@ -1,0 +1,73 @@
+# Contract Capture (Phase 0)
+
+The TypeScript public surface is the migration oracle. Capture it before touching MoonBit, and treat any later deviation as a regression.
+
+## 1. Inventory exported symbols + signatures
+
+Generate the authoritative declaration from the source as it ships today:
+
+```bash
+# If the package already ships .d.ts, snapshot it as-is:
+cp dist/index.d.ts contract/index.d.ts
+
+# Otherwise emit declarations from source:
+npx tsc --declaration --emitDeclarationOnly --outDir contract/ src/index.ts
+```
+
+Also record the *entry map* — what consumers actually import:
+
+```bash
+node -e 'const p=require("./package.json"); console.log(JSON.stringify({main:p.main,module:p.module,types:p.types,exports:p.exports},null,2))'
+```
+
+Keep `contract/` under version control. The Phase 6 diff is `generated .d.ts` vs this snapshot.
+
+## 2. Classify each export's contract level
+
+Tag every export so you know how strict parity must be:
+
+| Level | Meaning | Typical exports |
+|---|---|---|
+| **byte-exact** | output bytes/string must match exactly | hashers, serializers, encoders, formatters |
+| **structural** | same object/JSON shape, field order may not matter | most data-returning functions |
+| **semantic** | a value that round-trips / is observationally equal | parsers paired with their serializer |
+
+Write the level next to each symbol in `contract/levels.md`. It decides how you write the parity assertion in Phase 7.
+
+## 3. Freeze the test suite as the oracle
+
+The existing TS tests are the cheapest, highest-signal parity gate. Two moves:
+
+- **Keep them runnable against a built artifact.** Note how they import the module (`import {x} from "../src"` vs `from "../dist"`). In Phase 7 you will repoint that import at the `moon build` output.
+- **Generate fixtures from the *source* runtime**, never by hand. Pin the runtime version. Cover: ordinary cases, boundary values (0, empty, max-int, 2^53 ±1), malformed input, error paths, and side effects.
+
+```bash
+# Example: snapshot real outputs from the current implementation as fixtures
+node scripts/gen-fixtures.mjs > contract/fixtures.json   # calls the TS impl, writes {input, output} pairs
+```
+
+These fixtures port directly into MoonBit `inspect`/`assert_eq` tests during Phase 3.
+
+## 4. Record runtime + format facts
+
+Capture the things that silently break consumers if changed:
+
+- Module format(s): ESM, CJS, or dual (check `package.json` `type`, `exports` conditions).
+- Node/Deno/Bun/browser/Worker target(s).
+- Error contract: does it `throw Error`, reject a Promise, or return a discriminated result? With what message/shape?
+- Async-ness of each export (sync vs returns `Promise`).
+- Numeric expectations: which `number` fields can exceed 2^53, which are really `bigint`.
+
+## Output of Phase 0
+
+A `contract/` directory containing:
+
+```
+contract/
+├── index.d.ts        # frozen signature snapshot — Phase 6 diffs against this
+├── levels.md         # per-export contract level (byte/structural/semantic)
+├── fixtures.json     # source-generated input/output pairs — Phase 3 tests
+└── runtime.md        # formats, targets, error/async/numeric facts
+```
+
+You do not start Phase 1 until this exists.

--- a/lang/ts2moonbit-migration/references/parity-verification.md
+++ b/lang/ts2moonbit-migration/references/parity-verification.md
@@ -1,0 +1,64 @@
+# Parity Verification & Cutover (Phase 7)
+
+Unit tests inside MoonBit prove the port compiles and matches your fixtures. They do **not** prove the contract holds for real consumers. Verify against the original test suite and real traffic before switching. For the full gate discipline, load `translate-programming-language`.
+
+## 1. Run the original TypeScript test suite against the built artifact
+
+This is the highest-signal gate: the tests written for the TS implementation, run unchanged against the MoonBit-built `.js`.
+
+- Repoint the test import from the TS source to the build output:
+  ```ts
+  // before: import { parse } from "../src/index";
+  import { parse } from "../_build/js/release/build/pkg.js";
+  ```
+  Prefer a path alias / `tsconfig` `paths` or a single barrel module so you flip the source in one place.
+- Run the suite (`vitest`, `jest`, `node --test`, whatever the project uses).
+- Green = the public behavior matches for every case the original authors cared about.
+
+If the suite imports deep internal modules that no longer exist in MoonBit, that's expected — only the **public-API tests** are the contract. Quarantine internal-only tests; they were testing the old implementation, not the contract.
+
+## 2. Fixture parity
+
+Re-run the Phase 0 `contract/fixtures.json` pairs through the built artifact and assert by contract level:
+
+| Level | Assertion |
+|---|---|
+| byte-exact | `output === expected` (string/bytes equality) |
+| structural | deep-equal ignoring key order; or canonical-JSON compare |
+| semantic | round-trip: `serialize(parse(x))` equals canonical form |
+
+Cover the boundary cases you generated: empty, 0, `2^53 ± 1`, non-ASCII, NUL/high-bit bytes, malformed input, and every error path. Numeric and byte/text mistakes surface here.
+
+## 3. Error-contract parity
+
+Confirm the *shape* of failure matches, not just success:
+
+- A thrown `Error` still throws, with the same `message` (or documented change).
+- A rejected `Promise` still rejects (not resolves with an error value, or vice-versa).
+- A returned result object keeps its `{ok, error}` shape.
+
+## 4. Shadow / replay (services)
+
+For a ported Node service (typically on `mizchi/x`):
+
+- Mirror real requests to both the TS and MoonBit implementations; diff responses, status codes, headers, and side effects (files written, messages emitted).
+- Run a production-shaped benchmark — check latency, throughput, and resource use against the TS baseline. A correct-but-slow port can still be a regression.
+
+## 5. Cutover
+
+- Canary a small traffic slice with explicit rollback thresholds on error rate and the diff metric.
+- Keep the TypeScript implementation deployable for at least one rollback window after switching.
+- Only after the window closes (and the `.d.ts` diff is clean) retire the TS source.
+
+## Release gates checklist
+
+Do not call the migration done until:
+
+- [ ] Generated `.d.ts` matches the Phase 0 snapshot (or every diff is documented).
+- [ ] Original public-API test suite passes against the built `.js`.
+- [ ] All fixture pairs pass at their declared contract level; pending/skip = 0.
+- [ ] Error/async/format contract verified (throws-vs-rejects, ESM-vs-CJS).
+- [ ] Numeric boundaries (2^53, 32-bit wrap) and byte/text cases covered.
+- [ ] `moon check`, `moon test`, `moon fmt` clean.
+- [ ] Shadow/replay diff within threshold and benchmarks show no unacceptable regression (services).
+- [ ] Rollback path tested; TS implementation still deployable for the rollback window.

--- a/lang/ts2moonbit-migration/references/toolkit-map.md
+++ b/lang/ts2moonbit-migration/references/toolkit-map.md
@@ -10,10 +10,14 @@ The base layer. JavaScript built-ins (`Date`, `RegExp`, `Math`), Web Standard AP
 ```bash
 moon add mizchi/js
 ```
-```json
-// moon.pkg.json (or moon.pkg DSL import block)
-{ "import": ["mizchi/js/core", "mizchi/js"] }
 ```
+// src/moon.pkg (DSL form — verified)
+import {
+  "mizchi/js/core",
+  "mizchi/js",
+}
+```
+(The JSON form `moon.pkg.json` with `{ "import": ["mizchi/js/core", "mizchi/js"] }` works too. Pick one per package — don't mix.)
 
 Module sub-layout (import only what you use):
 - `mizchi/js/core` — `Any`, unsafe casts, the FFI primitives
@@ -55,15 +59,19 @@ moon add mizchi/cloudflare
 
 ## The `Any` escape hatch (mizchi/js/core)
 
-`Any` mirrors TypeScript `any` and is how you make progress before every type is pinned:
+`Any` (`@core.Any`) mirrors TypeScript `any` and is how you make progress before every type is pinned. Verified API (mizchi/js 0.12.1):
 
 ```mbt nocheck
-// zero-cost casts
-let a : Any = any(value)         // T -> Any
-let n : Int = obj["age"].cast()  // property access + cast
-obj["key"] = any(v)              // property set
-let r = obj._call("method", [any(x)])  // method call
+let a : @core.Any = @core.any(value)      // T -> Any
+let obj = @core.new_object()              // {} 
+obj._set("age", @core.any(30))            // obj.age = 30   (property set)
+let n : Int = obj._get("age").cast()      // obj.age + cast (property get)
+let first = arr._get_by_index(0)          // arr[0]
+let r = obj._call("method", [@core.any(x)])  // obj.method(x)
+let r2 = fn_any._invoke([@core.any(x)])      // fn(x)
 ```
+
+Note: property access is the methods `_get` / `_set` / `_get_by_index`, **not** `obj["key"]` bracket syntax. In the `.d.ts`, an exported `@core.Any` surfaces as TypeScript `any`.
 
 Strategy: port with `Any` first to get it compiling, then tighten the hot paths and the public boundary to concrete types. The boundary (anything in `link.js.exports`) should end up fully typed so the generated `.d.ts` matches the contract.
 
@@ -80,5 +88,7 @@ Strategy: port with `Any` first to get it compiling, then tighten the hot paths 
 | `Deno.*` / `Bun.*` | `mizchi/js_deno` / `mizchi/js_bun` |
 | `@cloudflare/workers-types` | `mizchi/cloudflare` |
 | anything with no binding | minimal `extern "js"` + `#module("pkg")` (see `moonbit-js-binding`) |
+
+> `supported_targets` warning: `mizchi/js` declares it, so `moon check` warns your package should too. For a leaf/app being migrated, declare it to silence the warning — in the `moon.pkg` DSL the verified syntax is the string expression form `supported_targets: "js"` (not `["js"]`, which warns "legacy array syntax"); in `moon.pkg.json` use `"supported-targets": ["js"]`. For a **library you republish**, prefer gating individual FFI files via `targets: { "f.mbt": ["js"] }` instead — a package-level `supported_targets` propagates and can block downstream consumers on other backends (see `moonbit-js-binding`).
 
 > Versioning note: package boundaries have shifted across releases (e.g. npm bindings moved out of `mizchi/js` into `mizchi/npm_typed` around v0.11; browser split into `mizchi/js_browser`). Run `moon add <pkg>` and check the resolved version in `moon.mod.json`; if an import path 404s, the binding likely lives in a sibling package now.

--- a/lang/ts2moonbit-migration/references/toolkit-map.md
+++ b/lang/ts2moonbit-migration/references/toolkit-map.md
@@ -1,0 +1,84 @@
+# The mizchi Toolkit Map
+
+Choose a binding layer by the *surface* the TypeScript code touches. Prefer an existing binding over hand-written `extern "js"`; when no binding exists, write a minimal FFI wrapper per the `moonbit-js-binding` skill.
+
+## Packages
+
+### `mizchi/js` — core JS / Web Standard / Node built-ins
+The base layer. JavaScript built-ins (`Date`, `RegExp`, `Math`), Web Standard APIs (`fetch`, `crypto`, streams), and `node:*` built-ins.
+
+```bash
+moon add mizchi/js
+```
+```json
+// moon.pkg.json (or moon.pkg DSL import block)
+{ "import": ["mizchi/js/core", "mizchi/js"] }
+```
+
+Module sub-layout (import only what you use):
+- `mizchi/js/core` — `Any`, unsafe casts, the FFI primitives
+- `mizchi/js/builtins/*` — `Date`, `RegExp`, `Math`, JSON, …
+- `mizchi/js/web/*` — `fetch`, `crypto`, WebGPU, streams
+- `mizchi/js/node` — Node standard library
+
+### `mizchi/js_browser` — DOM and browser-only APIs
+DOM, canvas, IndexedDB, storage, service workers. Split out so non-browser targets don't pull it in.
+```bash
+moon add mizchi/js_browser
+```
+
+### `mizchi/js_deno`, `mizchi/js_bun` — runtime-specific APIs
+Add only for the runtime you target.
+```bash
+moon add mizchi/js_deno   # or: moon add mizchi/js_bun
+```
+
+### `mizchi/npm_typed` — npm package bindings (separate repo)
+React, Preact, React Router, Hono, better-auth, Vercel AI SDK, Claude Code SDK, Zod, PGlite, DuckDB, Drizzle, and ~50 more.
+```bash
+moon add mizchi/npm_typed
+```
+If your dependency is covered here, use it instead of binding the package yourself.
+
+### `mizchi/x` — cross-target async backend
+Node.js backend compatibility layer for `moonbitlang/async`. Same source runs on `--target native` (delegating to `moonbitlang/async`) and `--target js` (via JS FFI). Provides: process exec (`spawn`/`run`/pipes), filesystem, HTTP client/server, WebSocket, TLS, TCP/UDP, and async primitives (queues, condition variables, semaphores).
+```bash
+moon add mizchi/x
+```
+Use this **instead of** hand-binding `node:fs`/`node:http`/`node:child_process` whenever the ported code should also be runnable natively. Depends on `moonbitlang/async` and `moonbitlang/x`.
+
+### `mizchi/cloudflare` — Cloudflare Workers (separate repo)
+Workers runtime bindings. Pair with `cloudflare/mbt-worker-bundle` for the build/bundle step.
+```bash
+moon add mizchi/cloudflare
+```
+
+## The `Any` escape hatch (mizchi/js/core)
+
+`Any` mirrors TypeScript `any` and is how you make progress before every type is pinned:
+
+```mbt nocheck
+// zero-cost casts
+let a : Any = any(value)         // T -> Any
+let n : Int = obj["age"].cast()  // property access + cast
+obj["key"] = any(v)              // property set
+let r = obj._call("method", [any(x)])  // method call
+```
+
+Strategy: port with `Any` first to get it compiling, then tighten the hot paths and the public boundary to concrete types. The boundary (anything in `link.js.exports`) should end up fully typed so the generated `.d.ts` matches the contract.
+
+## Picking layer by source import
+
+| TS import you see | Use |
+|---|---|
+| `fetch`, `crypto`, `TextEncoder`, `URL`, `structuredClone` | `mizchi/js` (web) |
+| `Date`, `Math`, `RegExp`, `JSON` | `mizchi/js` (builtins) |
+| `node:fs`, `node:path`, `node:os` (js-only ok) | `mizchi/js` (node) |
+| `node:child_process`, `node:net`, `node:http` server, `ws` (want native too) | `mizchi/x` |
+| `document`, `window`, `HTMLCanvasElement`, `indexedDB` | `mizchi/js_browser` |
+| `react`, `hono`, `zod`, `ai`, `drizzle-orm` | `mizchi/npm_typed` |
+| `Deno.*` / `Bun.*` | `mizchi/js_deno` / `mizchi/js_bun` |
+| `@cloudflare/workers-types` | `mizchi/cloudflare` |
+| anything with no binding | minimal `extern "js"` + `#module("pkg")` (see `moonbit-js-binding`) |
+
+> Versioning note: package boundaries have shifted across releases (e.g. npm bindings moved out of `mizchi/js` into `mizchi/npm_typed` around v0.11; browser split into `mizchi/js_browser`). Run `moon add <pkg>` and check the resolved version in `moon.mod.json`; if an import path 404s, the binding likely lives in a sibling package now.

--- a/lang/ts2moonbit-migration/references/toolkit-map.md
+++ b/lang/ts2moonbit-migration/references/toolkit-map.md
@@ -59,7 +59,7 @@ moon add mizchi/cloudflare
 
 ## The `Any` escape hatch (mizchi/js/core)
 
-`Any` (`@core.Any`) mirrors TypeScript `any` and is how you make progress before every type is pinned. Verified API (mizchi/js 0.12.1):
+`Any` (`@core.Any`) mirrors TypeScript `any`. Treat it as a **boundary-only** tool — it belongs in adapter files, not the core (see `boundary-and-core.md`). Verified API (mizchi/js 0.12.1):
 
 ```mbt nocheck
 let a : @core.Any = @core.any(value)      // T -> Any
@@ -73,7 +73,7 @@ let r2 = fn_any._invoke([@core.any(x)])      // fn(x)
 
 Note: property access is the methods `_get` / `_set` / `_get_by_index`, **not** `obj["key"]` bracket syntax. In the `.d.ts`, an exported `@core.Any` surfaces as TypeScript `any`.
 
-Strategy: port with `Any` first to get it compiling, then tighten the hot paths and the public boundary to concrete types. The boundary (anything in `link.js.exports`) should end up fully typed so the generated `.d.ts` matches the contract.
+Strategy: port with `Any` first to get it compiling, then pull the logic down into typed idiomatic core modules and leave only marshalling in the adapter. The exported boundary should end up with concrete signatures so the generated `.d.ts` matches the contract; the core should have no `Any` at all.
 
 ## Picking layer by source import
 

--- a/lang/ts2moonbit-migration/references/type-mapping.md
+++ b/lang/ts2moonbit-migration/references/type-mapping.md
@@ -80,7 +80,7 @@ Match the Phase 0 error contract: if consumers `catch` an `Error` with a specifi
 
 ## Boundary-leak checklist (verify in Phase 6 `.d.ts` diff)
 
-These emit MoonBit-internal shapes into the generated `.d.ts` — fix at the boundary:
+These emit MoonBit-internal shapes into the generated `.d.ts`. Fix them in the boundary adapter — keep the rich type in the core and convert to a JS-friendly shape at the export (see `boundary-and-core.md`):
 
 1. `Int64`/`UInt64` in a signature → `.d.ts` shows `bigint`, not `number`.
 2. data-carrying `enum` → tagged-object type; replace with struct or constructor fns.

--- a/lang/ts2moonbit-migration/references/type-mapping.md
+++ b/lang/ts2moonbit-migration/references/type-mapping.md
@@ -28,9 +28,15 @@ TypeScript distinguishes `T`, `T | undefined`, `T | null`, and `T | null | undef
 | `T \| null \| undefined` | dedicated 3-state, or `Nullish[T]` | split with both checks; never `Some(null)` |
 | optional property `x?: T` | `T?` field | absent property ≈ `undefined` |
 
+`mizchi/js/core` already provides these — don't hand-roll them:
+
 ```mbt nocheck
-pub extern "js" fn is_undefined(v : Any) -> Bool = #| (v) => v === undefined
-pub extern "js" fn is_null(v : Any) -> Bool = #| (v) => v === null
+@core.is_undefined(v)   // v === undefined
+@core.is_null(v)        // v === null
+@core.is_nullish(v)     // v == null  (null OR undefined)
+@core.nullable(opt)     // T? -> Any  (None becomes null/undefined per impl)
+@core.from_option(opt)  // T? -> Any
+@core.identity_option(v) // Any -> T?  (nullish-aware)
 ```
 
 If the contract never produces `null` (only `undefined`), `T?` is fine — confirm from the Phase 0 fixtures, don't assume.
@@ -79,4 +85,4 @@ These emit MoonBit-internal shapes into the generated `.d.ts` — fix at the bou
 1. `Int64`/`UInt64` in a signature → `.d.ts` shows `bigint`, not `number`.
 2. data-carrying `enum` → tagged-object type; replace with struct or constructor fns.
 3. `Map[K,V]`, `Result[_]`, `Json`, trait objects → internal runtime layout; convert to structs/arrays/`Any`.
-4. exported `async fn` → must show `Promise<T>` (needs `run_async` at the export — see `build-and-publish.md`).
+4. exported async returning `@core.Promise[T]` → `.d.ts` shows `any` (external type), even though JS receives a real `Promise`. Document the resolved type in a hand-maintained overlay `.d.ts` if consumers need `Promise<T>` (see `build-and-publish.md`).

--- a/lang/ts2moonbit-migration/references/type-mapping.md
+++ b/lang/ts2moonbit-migration/references/type-mapping.md
@@ -1,0 +1,82 @@
+# TypeScript → MoonBit Type Mapping
+
+Classify every field, parameter, and return by *meaning* before picking a MoonBit type. The TypeScript analog of OCaml's `string`-vs-`Bytes` trap is `number` (one type covering ints, floats, ids, and bitfields) and the `null`/`undefined` split.
+
+## Primitives
+
+| TypeScript | MoonBit | Notes |
+|---|---|---|
+| `boolean` | `Bool` | direct |
+| `number` integer, `\|x\| < 2^53` | `Int` (signed 32-bit wrapping) or `UInt` | MoonBit has no `Int32`; `Int` wraps at 32 bits — fine for most app ints |
+| `number` integer that can exceed 2^53 | `BigInt` (or `Int64`/`UInt64`) | ids, epoch-millis, bitfields. `Int64` surfaces in `.d.ts` as `bigint` |
+| `number` float | `Double` | use `Float` only if the contract is 32-bit |
+| `bigint` | `BigInt` / `Int64` | direct; `.d.ts` shows `bigint` |
+| `string` (human text / labels) | `String` | UTF-16; `String::length()` counts code units, not bytes |
+| `string` (binary, base64-decoded, protocol bytes) | `Bytes` | classify by meaning, not by TS type |
+| `Uint8Array` | `Bytes` / `FixedArray[Byte]` | no copy across the boundary |
+
+> **`number` precision rule.** JS `number` is IEEE-754 double. `Int` is safe for `\|x\| < 2^31` arithmetic and round-trips for `\|x\| < 2^53`. Anything that can grow past 2^53 (snowflake ids, nanosecond timestamps) must be `BigInt` — but check the *contract*: if JS consumers pass/read a plain `number`, you may need to keep `Double` and document the precision ceiling rather than switch them to `bigint`.
+
+## Nullability — do not collapse
+
+TypeScript distinguishes `T`, `T | undefined`, `T | null`, and `T | null | undefined`. MoonBit `T?` only models present/absent.
+
+| TS | MoonBit | How |
+|---|---|---|
+| `T \| undefined` | `T?` | check `is_undefined(v)` → `None`/`Some` |
+| `T \| null` | `Nullable[T]` wrapper | explicit `is_null` branch; `null ≠ undefined` |
+| `T \| null \| undefined` | dedicated 3-state, or `Nullish[T]` | split with both checks; never `Some(null)` |
+| optional property `x?: T` | `T?` field | absent property ≈ `undefined` |
+
+```mbt nocheck
+pub extern "js" fn is_undefined(v : Any) -> Bool = #| (v) => v === undefined
+pub extern "js" fn is_null(v : Any) -> Bool = #| (v) => v === null
+```
+
+If the contract never produces `null` (only `undefined`), `T?` is fine — confirm from the Phase 0 fixtures, don't assume.
+
+## Compound types
+
+| TypeScript | MoonBit | Notes |
+|---|---|---|
+| `T[]` / `Array<T>` | `Array[T]` | growable; `FixedArray[T]` for fixed |
+| `readonly T[]` | `ArrayView[T]` / `ReadOnlyArray[T]` | cheap read-only slice |
+| `[A, B]` tuple | `(A, B)` | direct |
+| object / interface / record | `struct` | update syntax `{ ..old, field: v }` |
+| `Record<string, V>` / `Map` | **don't pass `Map` across the boundary** | use `struct`, `Array[(String, V)]`, or `Any` at the edge |
+| discriminated union | `enum` | data-carrying enums are awkward to build from JS — see below |
+| string-literal union `"a" \| "b"` | `enum` (no payload) or `String` | enum if used internally; keep `String` at the boundary if JS passes raw strings |
+| `Date` | `mizchi/js` `Date` binding | not a MoonBit primitive |
+| `RegExp` | `mizchi/js` `RegExp` binding | — |
+| `Promise<T>` | `async fn` returning `T` + `.wait()` | see Async below |
+| `(a: A) => R` | `FuncRef[(A) -> R]` or closure | — |
+| `any` / `unknown` | `Any` (mizchi/js/core) | tighten before it reaches the public boundary |
+| `object` opaque (DOM node, handle) | `#external pub type` | wrap + `%identity` cast (see `moonbit-js-binding`) |
+
+## Discriminated unions / enums at the boundary
+
+A MoonBit `enum Result { Ok(Int); Err(String) }` compiles to a tagged-object shape that is clumsy to construct from TypeScript and leaks MoonBit's representation into the `.d.ts`. At the **public boundary**, prefer one of:
+
+- a plain `struct` with a discriminant field (`{ kind: String, value: ... }`), or
+- a pair of constructor functions (`ok(x)`, `err(msg)`) exported to JS,
+
+and keep the rich `enum` internal. Inside MoonBit, use `enum` freely.
+
+## Errors
+
+| TS error style | MoonBit |
+|---|---|
+| `throw new Error(msg)` | `raise` with a `suberror`; bridge to a thrown JS `Error` at the export if the contract throws |
+| rejected `Promise` | `async fn ... raise E`; the bridge rejects the JS Promise |
+| returned result object `{ok:false,error}` | mirror as a `struct` (keeps the contract structural) |
+
+Match the Phase 0 error contract: if consumers `catch` an `Error` with a specific `message`, your export must still throw that.
+
+## Boundary-leak checklist (verify in Phase 6 `.d.ts` diff)
+
+These emit MoonBit-internal shapes into the generated `.d.ts` — fix at the boundary:
+
+1. `Int64`/`UInt64` in a signature → `.d.ts` shows `bigint`, not `number`.
+2. data-carrying `enum` → tagged-object type; replace with struct or constructor fns.
+3. `Map[K,V]`, `Result[_]`, `Json`, trait objects → internal runtime layout; convert to structs/arrays/`Any`.
+4. exported `async fn` → must show `Promise<T>` (needs `run_async` at the export — see `build-and-publish.md`).

--- a/lang/ts2moonbit-migration/references/type-mapping.md
+++ b/lang/ts2moonbit-migration/references/type-mapping.md
@@ -11,9 +11,11 @@ Classify every field, parameter, and return by *meaning* before picking a MoonBi
 | `number` integer that can exceed 2^53 | `BigInt` (or `Int64`/`UInt64`) | ids, epoch-millis, bitfields. `Int64` surfaces in `.d.ts` as `bigint` |
 | `number` float | `Double` | use `Float` only if the contract is 32-bit |
 | `bigint` | `BigInt` / `Int64` | direct; `.d.ts` shows `bigint` |
-| `string` (human text / labels) | `String` | UTF-16; `String::length()` counts code units, not bytes |
+| `string` (human text / labels) | `String` | UTF-16; `String::length()` counts code units, not bytes. **`<`/`>` on `String` order by length first, not lexicographically** — see warning below |
 | `string` (binary, base64-decoded, protocol bytes) | `Bytes` | classify by meaning, not by TS type |
 | `Uint8Array` | `Bytes` / `FixedArray[Byte]` | no copy across the boundary |
+
+> **`String` comparison is not lexicographic.** MoonBit's `<`/`>`/`compare` on `String` order by **length first**, then content — so `"beta" < "alpha"` is `true` (4 < 5). JS string comparison (and most contracts: sort orders, semver identifiers, range keys) is lexicographic by code unit. When the contract depends on string ordering, write an explicit code-unit comparison (`a[i] < b[i]` over `UInt16`, shorter-is-less on a common prefix) instead of `<`. *(Found while porting `semver`: prerelease identifier precedence was inverted until switched to explicit comparison.)*
 
 > **`number` precision rule.** JS `number` is IEEE-754 double. `Int` is safe for `\|x\| < 2^31` arithmetic and round-trips for `\|x\| < 2^53`. Anything that can grow past 2^53 (snowflake ids, nanosecond timestamps) must be `BigInt` — but check the *contract*: if JS consumers pass/read a plain `number`, you may need to keep `Double` and document the precision ceiling rather than switch them to `bigint`.
 


### PR DESCRIPTION
A new `lang/ts2moonbit-migration` skill: a playbook for migrating TypeScript codebases to MoonBit on the `js` target while preserving the JavaScript API contract, using the mizchi ecosystem (`mizchi/js`, `mizchi/x`, `mizchi/npm_typed`, `js_browser/deno/bun`, `cloudflare`).

Inspired by moonbitlang/skills' `ocaml2moonbit-migration`. Composes the existing `moonbit-js-binding` (FFI mechanics) and `translate-programming-language` (parity methodology) skills rather than duplicating them.

## Core principles
- **The contract is the spec.** The TS public surface (`.d.ts`, exports, formats, tests) is the migration oracle; the build must satisfy it unchanged.
- **JS-compatible boundary, idiomatic MoonBit core.** A thin adapter layer at the boundary (`Any`/`_get`/`_set`/`throw_error`/`promisify`), an idiomatic core behind it (`enum`/`match`, `struct`, `Result`/`raise`) with no JS types.
- **Library triage** before porting: does the library's reason-to-exist survive in MoonBit, and is it domain-logic (rich core) vs runtime-mechanics (FFI-heavy)?

## Contents
- `SKILL.md`: toolkit map, 8-phase workflow, two-layer architecture, library triage, TS→MoonBit type table, decision table, pitfalls.
- `references/`: contract-capture, toolkit-map, boundary-and-core, type-mapping, build-and-publish (`.d.ts` diff gate), parity-verification.
- `README.md`: listed under Languages.

## Verified on a real toolchain
Installed moon 0.1.20260522 / moonc v0.9.3 + mizchi/js 0.12.1 and validated the workflow end-to-end (FFI, exports, `.d.ts`, `Any` object and `Promise` round-trips through Node). Then dogfooded the skill by porting two real npm packages against the actual libraries as oracles:

- **semver@7.8.1** (domain-logic): idiomatic `enum`/`struct` core + `match`-based precedence, thin boundary — **198/198** parity.
- **immer@10** (runtime-mechanics): Proxy copy-on-write in `extern "js"`, thin pass-through — **12/12** contract parity incl. structural sharing.

The dogfood surfaced (and the skill now documents) two real gotchas: MoonBit `String` `<` orders by length, not lexicographically; and a core static method sharing a name with a boundary export produces a duplicate JS export.

https://claude.ai/code/session_01Czcmsq7F35LDJn57RsVLXj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Czcmsq7F35LDJn57RsVLXj)_