### PR TITLE
fix(nix-setup): add openssl to apm.nix buildInputs for Linux

### DIFF
--- a/tooling/nix-setup/SKILL.md
+++ b/tooling/nix-setup/SKILL.md
@@ -539,6 +539,11 @@ The Determinate installer is recommended. Doing it manually on Apple Silicon req
 
 Add `stdenv.cc.cc.lib` to `buildInputs`. The same fix used in `apm.nix`.
 
+For PyInstaller-bundled binaries (like apm), the embedded CPython `_ssl` /
+`_hashlib` modules also link `libssl.so.3` / `libcrypto.so.3` — add
+`pkgs.openssl` to `buildInputs` too. macOS skips `autoPatchelfHook`, so this
+gap only surfaces on Linux (e.g. in CI).
+
 ### Updating flake inputs
 
 ```bash

--- a/tooling/nix-setup/assets/apm.nix
+++ b/tooling/nix-setup/assets/apm.nix
@@ -42,6 +42,10 @@ stdenv.mkDerivation {
   buildInputs = lib.optionals stdenv.isLinux [
     stdenv.cc.cc.lib
     pkgs.zlib
+    # PyInstaller's bundled _ssl / _hashlib modules link libssl.so.3 /
+    # libcrypto.so.3. Without openssl here, autoPatchelf fails on Linux
+    # (macOS skips autoPatchelf so the gap is invisible there).
+    pkgs.openssl
   ];
 
   dontConfigure = true;


### PR DESCRIPTION
## Problem

`apm.nix` fails to build on Linux. `autoPatchelfHook` cannot satisfy
`libssl.so.3` / `libcrypto.so.3`, wanted by PyInstaller's bundled CPython
`_ssl` / `_hashlib` modules:

```
error: auto-patchelf could not satisfy dependency libssl.so.3 wanted by ..._ssl.cpython-312-x86_64-linux-gnu.so
error: auto-patchelf could not satisfy dependency libcrypto.so.3 wanted by ..._hashlib.cpython-312-x86_64-linux-gnu.so
```

macOS skips `autoPatchelfHook`, so the gap was invisible there — it only
surfaces on Linux (e.g. GitHub Actions CI).

## Fix

Add `pkgs.openssl` to the Linux `buildInputs`, and document the case in the
SKILL.md autoPatchelf troubleshooting section.

## Verification

The identical change went green on a Linux GitHub Actions run in
`mizchi/project-template` (which vendors this `apm.nix`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)