### PR TITLE
Update moonbit-practice for v0.9–v0.10.0 and config DSL

### DIFF
--- a/lang/moonbit-practice/SKILL.md
+++ b/lang/moonbit-practice/SKILL.md
@@ -38,7 +38,8 @@ moon ide outline src/parser.mbt
 ### Other Rules
 
 - Use `moon doc '<Type>'` to explore APIs before implementing
-- Check reference/configuration.md before editing moon.pkg.json / moon.mod.json
+- **Config format: prefer the DSL `moon.mod` / `moon.pkg`** over the deprecated-pending `moon.mod.json` / `moon.pkg.json`. `moon fmt` migrates JSON → DSL. Samples: `assets/moon.mod`, `assets/moon.pkg`. Check reference/configuration.md before editing either
+- **Multiple modules in one repo → use a workspace** (`moon.work`), not standalone modules. `moon work init <dirs>` creates the manifest; members share one build context and resolve each other locally. See reference/configuration.md "Workspace"
 - Check reference/language.md for detailed language feature examples (types, traits, pattern matching, etc.)
 - Check reference/mbtx.md for single-file `.mbtx` scripts (`moon run script.mbtx`, stdin via `moon run -`, inline `import { }` block; nightly only)
 
@@ -56,6 +57,11 @@ moon ide outline src/parser.mbt
 - **Legacy syntax**: `function_name!(...)` and `function_name(...)?` are deprecated
 - **`for { ... }` is deprecated** - use `for ;; { ... }` or `while true { ... }` for infinite loops
 - **Cross-package `.` syntax for `impl` removed** - `.` method call only works within the same package
+- **`trait`/`impl` methods now require the `fn` keyword (v0.10.0)** - `moon fmt` migrates old code; see "Traits and impl" below
+- **`try?` is deprecated (v0.10.0)** - use `Ok(expr) catch { e => Err(e) }` to get a `Result`
+- **Struct `fn new(..)` constructor removed (v0.10.0)** - use a user-defined constructor `fn Type::Type(..)`
+- **`immut/array` replaced by `immut/vector` (v0.9)** - update imports/deps; better performance
+- **`inspect` superseded by `debug_inspect` for snapshot tests (v0.9.2)** - `Show` for container types (`Array`/`Map`/`Set`/`Option`/`Result`/tuples) is deprecated; see "Snapshot Tests"
 
 ## Common Syntax Mistakes by AI
 
@@ -96,6 +102,62 @@ assert_true!(true)
 assert_true(true)
 ```
 
+### Traits and impl require `fn` (v0.10.0)
+
+```moonbit
+///| NG: method without fn (deprecated, warns then removed)
+trait I {
+  f(Self) -> Unit
+}
+impl I for Int with f(_) {}
+
+///| OK: fn keyword on both the trait method and the impl
+trait I {
+  fn f(Self) -> Unit
+}
+impl I for Int with fn f(_) {}
+```
+
+Polymorphic trait methods: the method's own type parameters go **after `fn`**,
+the impl's own type parameters stay after `impl`.
+
+```moonbit
+trait Logger {
+  fn[X : Show] write_object(Self, X) -> Unit
+}
+impl Logger for StringBuilder with fn write_object(self, x) {
+  self.write_string(x.to_string())
+}
+
+impl[A] Poly for Array[A] with fn[X] f(self, x : X) { ... }
+//   ^^^ impl type params                  ^^^ method type params
+```
+
+`moon fmt` rewrites old trait/impl syntax automatically.
+
+### Structs, Constructors, Methods
+
+The removed `fn new(..)` special form is replaced by a plain user-defined
+constructor `fn Type::Type(..)`. Methods take the receiver as `self : Self`.
+
+```moonbit
+///| Struct with derives
+struct Point {
+  x : Int
+  y : Int
+} derive(Eq, Debug)
+
+///| User-defined constructor (replaces removed `fn new`)
+fn Point::Point(x : Int, y : Int) -> Point {
+  { x, y }  // field-punning struct literal
+}
+
+///| Method: receiver `self : Self`, last expression is the return value
+fn Point::manhattan(self : Self) -> Int {
+  self.x.abs() + self.y.abs()
+}
+```
+
 ### Multi-line Text
 
 ```moonbit
@@ -122,19 +184,44 @@ Avoid consecutive `///|` at the file beginning as they create separate blocks.
 
 ## Snapshot Tests
 
-`moon test -u` auto-updates `content=""` in `inspect(val)`.
+`moon test -u` auto-fills the empty `content=""` of `inspect(val)` /
+`debug_inspect(val)`. **Which to use (v0.9.2+):**
+
+- **Primitives / strings** → `inspect` (`Show` is fine here)
+- **Container types** (`Array`/`Map`/`Set`/`Option`/`Result`/tuples) **and custom
+  types** → `debug_inspect`, because `Show` for these containers is deprecated and
+  `Debug` gives structured, indented output. Keep `Show` for human-facing
+  formatting only.
+
+Choose by the inspected expression's **static type**, not the runtime value:
+`Result[Int, _]` is a container even when it holds `Ok(123)`, and the rule
+propagates — to snapshot/assert a custom type (even nested inside a container) the
+custom type must `derive(Debug)`, and equality via `@debug.assert_eq` additionally
+needs `derive(Eq)`.
 
 ```moonbit
 test "snapshot" {
-  inspect([1, 2, 3], content="")  // auto-filled by moon test -u
+  inspect("hello", content="")          // primitive/string -> inspect
+  debug_inspect([1, 2, 3], content="")  // container -> debug_inspect
+}
+
+///| Custom type: derive Debug to snapshot, derive Eq to assert_eq
+struct P {
+  x : Int
+} derive(Eq, Debug)
+
+test "custom type" {
+  debug_inspect(P::{ x: 1 }, content="")
+  @debug.assert_eq(P::{ x: 1 }, P::{ x: 1 })
 }
 ```
 
-After running:
+After `moon test -u`:
 
 ```moonbit
 test "snapshot" {
-  inspect([1, 2, 3], content="[1, 2, 3]")
+  inspect("hello", content="hello")
+  debug_inspect([1, 2, 3], content="[1, 2, 3]")
 }
 ```
 
@@ -252,6 +339,50 @@ for x in xs; sum = 0 {
 for ;; { ... }
 ```
 
+## List Comprehensions (v0.9.2+)
+
+`[for .. => body]` builds an array; add `if <guard>` before `=>` to filter.
+The same shape typed as `Iter[T]` yields a lazy iterator instead of an array.
+
+```moonbit
+let evens = [for i in 0..<100 if i % 2 == 0 => i]
+
+///| With loop state (v0.10.0): carries p1/p2 across iterations
+let fibs = [
+  for _ in 0..<10
+      p1 = 1, p2 = 0
+      p1 = p1 + p2, p2 = p1 => p1
+]
+
+///| Typed as Iter -> lazy
+let fib_iter : Iter[Int] = [for p1 = 1, p2 = 0;; p1 = p1 + p2, p2 = p1 => p1]
+```
+
+## Template Write `<+` (v0.10.0)
+
+`buf <+ expr` appends to a `StringBuilder` — terser than `write_string`, pairs
+well with `$|` interpolation for building markup/strings.
+
+```moonbit
+let buf = StringBuilder()
+buf <+ "<ul>"
+for item in items {
+  buf <+ $|<li>\{item}</li>
+}
+buf <+ "</ul>"
+buf.to_string()
+```
+
+## Regex Match `=~` (v0.9+)
+
+Stable regex matching (`s =~ re"..."`) replaces the experimental `lexmatch?`,
+with different semantics — check `moon doc` / docs before relying on capture,
+prefix (`before~`), or suffix (`after~`) binding forms.
+
+```moonbit
+let matched = s =~ re"abc"
+```
+
 ## String Constants
 
 `const` supports string concatenation and interpolation (v0.8.3+):
@@ -282,13 +413,18 @@ fn parse(s: String) -> Int raise ParseError {
   ...
 }
 
-///| Convert to Result
-let result : Result[Int, ParseError] = try? parse(s)
+///| Convert to Result — `try?` is deprecated (v0.10.0)
+let result : Result[Int, ParseError] = Ok(parse(s)) catch { e => Err(e) }
 
-///| Handle with try-catch
-parse(s) catch {
+///| Single expression with a fallback: omit `try`
+let n = parse(s) catch { _ => 0 }
+
+///| Full form: `noraise` branch handles the success value
+let n = try parse(s) catch {
   ParseError::InvalidEof => -1
   _ => 0
+} noraise {
+  v => v
 }
 ```
 
@@ -310,6 +446,8 @@ See `assets/publish-to-npm.yaml` for a minimal release-triggered publish workflo
 
 ## Assets
 
+- `assets/moon.mod` — module config sample in the new DSL (replaces moon.mod.json)
+- `assets/moon.pkg` — package config sample in the new DSL (replaces moon.pkg.json)
 - `assets/ci.yaml` — GitHub Actions CI (curl installer)
 - `assets/ci-nix.yaml` — GitHub Actions CI with Nix (moonbit-overlay)
 - `assets/publish-to-npm.yaml` — release-triggered npm publish with MoonBit build and OIDC Trusted Publishing

--- a/lang/moonbit-practice/assets/moon.mod
+++ b/lang/moonbit-practice/assets/moon.mod
@@ -1,0 +1,36 @@
+// moon.mod — module configuration (new DSL, replaces the deprecated moon.mod.json)
+//
+// The DSL allows comments and trailing commas. Top-level settings use `key = value`;
+// build-affecting settings go inside the `options( ... )` block.
+// Convert an existing moon.mod.json by running `moon fmt` in the module root.
+
+name = "username/project"
+
+version = "0.1.0"
+
+license = "MIT"
+
+repository = "https://github.com/username/project"
+
+description = "One-line description of the module"
+
+keywords = [ "cli", "example" ]
+
+readme = "README.md"
+
+// Default backend when none is passed on the command line (js | wasm | wasm-gc | native)
+preferred_target = "js"
+
+// Tweak warnings/alerts by number or name (prefix - to silence, + to enable)
+warnings = "-2"
+
+// Registry dependencies — version pinned inline with `@`. Omit the block if none.
+import {
+  "moonbitlang/x@0.4.45",
+  // "username/other@0.1.0",
+}
+
+options(
+  source: "src",          // source directory holding the packages
+  // exclude: [ "examples", "node_modules", "_build" ],  // paths kept out of the published package
+)

--- a/lang/moonbit-practice/assets/moon.pkg
+++ b/lang/moonbit-practice/assets/moon.pkg
@@ -1,0 +1,45 @@
+// moon.pkg — package configuration (new DSL, replaces the deprecated moon.pkg.json)
+//
+// One per package directory, alongside the .mbt files. Comments and trailing
+// commas are allowed. Convert an existing moon.pkg.json with `moon fmt`.
+
+// Normal imports. Add `@alias` after a path to import it under a short name.
+import {
+  "moonbitlang/core/builtin",
+  "username/project/util" @util,
+}
+
+// Test-only imports (the block may be empty). White-box variant: `for "wbtest"`.
+import {
+  "moonbitlang/core/test",
+} for "test"
+
+// Restrict this package to specific backends (optional, top-level)
+// supported_targets = "wasm"
+
+// Per-package warning tweaks (optional, top-level)
+// warnings = "-unused_value"
+
+options(
+  is_main: true,          // executable package containing `fn main`
+
+  // Conditional compilation: file -> backend conditions (and / or / not supported)
+  targets: {
+    "only_js.mbt": [ "js" ],
+    "native_only.mbt": [ "native" ],
+    "not_js.mbt": [ "not", "js" ],
+  },
+
+  // Backend link options
+  link: {
+    "js": {
+      "exports": [ "hello" ],
+      "format": "esm",       // esm (default) | cjs | iife
+    },
+  },
+
+  // Codegen step run before build (same shape as the legacy JSON form)
+  // "pre-build": [
+  //   { "input": "a.txt", "output": "a.mbt", "command": ":embed -i $input -o $output" },
+  // ],
+)

--- a/lang/moonbit-practice/reference/configuration.md
+++ b/lang/moonbit-practice/reference/configuration.md
@@ -4,211 +4,171 @@ title: "MoonBit Configuration Reference"
 
 # MoonBit Configuration Reference
 
+> **Prefer the DSL formats `moon.mod` / `moon.pkg`.** The JSON formats
+> `moon.mod.json` / `moon.pkg.json` are deprecated-pending and kept only for
+> existing projects. New projects should use the DSL. Ready-to-copy samples live
+> at `assets/moon.mod` and `assets/moon.pkg`.
+
 ## File Structure
 
 ```
 my-project/
-├── moon.mod.json    # Module configuration (project-wide)
+├── moon.mod        # Module configuration, project-wide (new DSL)
 └── src/
-    ├── moon.pkg       # Package configuration (new format)
+    ├── moon.pkg    # Package configuration (new DSL)
     └── main.mbt
 ```
 
-## Migrating from moon.pkg.json to moon.pkg
+## Migrating from JSON to the DSL
 
-`moon.pkg.json` is being migrated to the custom syntax `moon.pkg`. Convert with:
+`moon fmt` converts both files to the DSL in place:
 
 ```bash
-NEW_MOON_PKG=1 moon fmt
+moon fmt          # converts moon.mod.json -> moon.mod and moon.pkg.json -> moon.pkg
 ```
 
-This converts `moon.pkg.json` to `moon.pkg`.
+The DSL adds comments, trailing commas, and a more concise syntax. Top-level
+settings use `key = value`; build-affecting settings go inside `options( ... )`.
 
-## moon.pkg (New Format)
+---
 
-Compared to JSON: supports comments, trailing commas, and more concise syntax.
-
-### Imports
+## moon.mod (Module Configuration, new DSL)
 
 ```moonbit
-// Basic import
+name = "username/project"
+
+version = "0.1.0"
+
+license = "MIT"
+
+repository = "https://github.com/username/project"
+
+description = "One-line description"
+
+keywords = [ "cli", "example" ]
+
+readme = "README.md"
+
+// Default backend: js | wasm | wasm-gc | native
+preferred_target = "js"
+
+// Warning/alert tweaks (- silences, + enables; by number or name)
+warnings = "-2"
+
+// Registry dependencies, version pinned inline with `@`
 import {
-  "moonbitlang/async/io",
-  "path/to/pkg" as @alias,
+  "moonbitlang/x@0.4.45",
 }
 
-// Test imports
-import "test" {
-  "path/to/pkg5",
-}
-
-// White-box test imports
-import "wbtest" {
-  "path/to/pkg7",
-}
-```
-
-### Options
-
-```moonbit
 options(
-  "is-main": true,
-  "bin-name": "name",
-  link: { "native": { "cc": "gcc" } },
+  source: "src",                              // source directory
+  // exclude: [ "examples", "_build" ],       // paths kept out of the published package
 )
 ```
 
-### Comparison with JSON
+Field mapping from the old JSON keys: `preferred-target` → `preferred_target`,
+`warn-list` → `warnings`, `source`/`deps` move into `options(...)` / the `import`
+block respectively.
 
-| Feature | JSON Format | moon.pkg Format |
-|---------|-------------|-----------------|
-| Comments | ❌ Not supported | ✅ Supported |
-| Trailing comma | ❌ Not supported | ✅ Supported |
-| Readability | Low (verbose) | High (concise) |
+### Path dependencies
 
-## moon.mod.json (Module Configuration)
+The JSON `"deps": { "myuser/mod2": { "path": "../mod2" } }` becomes a path entry in
+the `import` block; for cross-module work prefer a workspace (`moon.work`, below).
 
-### Required Fields
+---
+
+## moon.pkg (Package Configuration, new DSL)
+
+```moonbit
+// Imports; `@alias` after a path imports it under a short name
+import {
+  "moonbitlang/core/builtin",
+  "username/project/util" @util,
+}
+
+// Test-only imports (block may be empty). White-box variant: `for "wbtest"`.
+import {
+  "moonbitlang/core/test",
+} for "test"
+
+// Optional, top-level
+supported_targets = "wasm"
+warnings = "-unused_value"
+
+options(
+  is_main: true,                              // executable package with `fn main`
+
+  // Conditional compilation: file -> backend conditions
+  targets: {
+    "only_js.mbt": [ "js" ],
+    "not_js.mbt": [ "not", "js" ],
+    "js_release.mbt": [ "and", [ "js" ], [ "release" ] ],
+  },
+
+  // Backend link options
+  link: {
+    "js": { "exports": [ "hello" ], "format": "esm" },          // esm | cjs | iife
+    "wasm-gc": { "exports": [ "hello" ], "use-js-builtin-string": true },
+  },
+
+  // Codegen step before build (same shape as legacy JSON)
+  "pre-build": [
+    { "input": "a.txt", "output": "a.mbt", "command": ":embed -i $input -o $output" },
+  ],
+)
+```
+
+- Conditions: `wasm`, `wasm-gc`, `js`, `native`, `debug`, `release`. Operators:
+  `and`, `or`, `not`.
+- `is_main` and `"is-main"` are both accepted; prefer the unquoted `is_main`.
+- `:embed` converts a file to MoonBit source (`--text` / `--binary`, `--name`).
+
+---
+
+## Legacy JSON formats (existing projects only)
+
+Equivalent JSON for reference when reading older code. Run `moon fmt` to migrate.
+
+### moon.mod.json
 
 ```json
 {
   "name": "username/project-name",
-  "version": "0.1.0"
-}
-```
-
-### Dependencies
-
-```json
-{
+  "version": "0.1.0",
   "deps": {
     "moonbitlang/x": "0.4.6",
     "username/other": { "path": "../other" }
-  }
-}
-```
-
-### Metadata
-
-```json
-{
+  },
+  "source": "src",
   "license": "MIT",
   "repository": "https://github.com/...",
   "description": "...",
-  "keywords": ["example", "test"]
-}
-```
-
-### Source Directory
-
-```json
-{
-  "source": "src"
-}
-```
-
-### Target Specification
-
-```json
-{
-  "preferred-target": "js"
-}
-```
-
-### Warning Configuration
-
-```json
-{
+  "keywords": ["example"],
+  "preferred-target": "js",
   "warn-list": "-2-4",
   "alert-list": "-alert_1"
 }
 ```
 
-## moon.pkg.json (Package Configuration)
-
-### Main Package
+### moon.pkg.json
 
 ```json
 {
-  "is-main": true
-}
-```
-
-### Dependencies
-
-```json
-{
+  "is-main": true,
   "import": [
     "moonbitlang/quickcheck",
     { "path": "moonbitlang/x/encoding", "alias": "lib" }
   ],
-  "test-import": [...],
-  "wbtest-import": [...]
-}
-```
-
-### Conditional Compilation
-
-```json
-{
-  "targets": {
-    "only_js.mbt": ["js"],
-    "only_wasm.mbt": ["wasm"],
-    "not_js.mbt": ["not", "js"],
-    "debug_only.mbt": ["debug"],
-    "js_release.mbt": ["and", ["js"], ["release"]]
-  }
-}
-```
-
-Conditions: `wasm`, `wasm-gc`, `js`, `debug`, `release`
-Operators: `and`, `or`, `not`
-
-### Link Options
-
-#### JS Backend
-
-```json
-{
-  "link": {
-    "js": {
-      "exports": ["hello", "foo:bar"],
-      "format": "esm"
-    }
-  }
-}
-```
-
-format: `esm` (default), `cjs`, `iife`
-
-#### Wasm Backend
-
-```json
-{
-  "link": {
-    "wasm-gc": {
-      "exports": ["hello"],
-      "use-js-builtin-string": true
-    }
-  }
-}
-```
-
-### Pre-build
-
-```json
-{
+  "test-import": [],
+  "targets": { "only_js.mbt": ["js"] },
+  "link": { "js": { "exports": ["hello"], "format": "esm" } },
   "pre-build": [
-    {
-      "input": "a.txt",
-      "output": "a.mbt",
-      "command": ":embed -i $input -o $output"
-    }
+    { "input": "a.txt", "output": "a.mbt", "command": ":embed -i $input -o $output" }
   ]
 }
 ```
 
-`:embed` converts files to MoonBit source (`--text` or `--binary`)
+---
 
 ## Warning Numbers
 
@@ -221,25 +181,24 @@ Common ones:
 
 Check all: `moonc build-package -warn-help`
 
-## Workspace (moon.work)
+## Workspace (moon.work) — managing multiple modules
 
-Multiple modules can share a single build context via a workspace.
-
-### Workflow
+**When a repo holds more than one module, manage them with a workspace
+(`moon.work`)** instead of standalone modules. Members share one build context
+and `_build/` directory, resolve each other locally, and keep dependency versions
+in sync. See https://docs.moonbitlang.com/ja/latest/toolchain/moon/workspace.html
+(experimental).
 
 ```bash
-# 1. Create modules
-moon new --user myuser mod1
-moon new --user myuser mod2
+# Create the manifest with initial members in one step (paths are module dirs)
+moon work init mod1 mod2
 
-# 2. Initialize workspace (creates moon.work)
+# ...or init empty, then add members later
 moon work init
-
-# 3. Add modules to workspace
 moon work use mod1 mod2
 ```
 
-This generates `moon.work`:
+This generates `moon.work` at the repo root:
 
 ```
 members = [
@@ -248,48 +207,38 @@ members = [
 ]
 ```
 
+`moon check` / `moon test` / `moon build` run from the workspace root operate
+across all members.
+
+### Workspace commands (verified, moon 0.1.20260618)
+
+| Command | Description |
+|---------|-------------|
+| `moon work init [paths...]` | Create the `moon.work` manifest, optionally with initial member dirs |
+| `moon work use <paths...>` | Add module directories to the manifest |
+| `moon work sync` | Sync workspace dependency versions into member manifests |
+
 ### Cross-module imports
 
-Add a path dependency in the consumer's `moon.mod.json`:
-
-```json
-{
-  "deps": {
-    "myuser/mod2": { "path": "../mod2" }
-  }
-}
-```
-
-Then import in `moon.pkg`:
+Depend on a sibling member by its module name in the consumer's `moon.mod`
+`import` block, then import the package in `moon.pkg`:
 
 ```moonbit
+// in mod1/src/moon.pkg
 import {
   "myuser/mod2" @mod2,
 }
 ```
 
-Use in code:
-
 ```moonbit
-///|
 fn main {
   println(@mod2.hello())
 }
 ```
 
-Run with:
-
-```bash
-moon run mod1/cmd/main
-```
-
-### Workspace commands
-
-| Command | Description |
-|---------|-------------|
-| `moon work init` | Create `moon.work` manifest |
-| `moon work use <dirs>` | Add modules to workspace |
-| `moon work sync` | Sync dependency versions across members |
+Run a specific member from the workspace root with `moon run <member-dir>`
+(e.g. `moon run mod1`). Use `moon work sync` after changing versions to propagate
+them across members.
 
 ## References
 

--- a/lang/moonbit-practice/reference/ffi.md
+++ b/lang/moonbit-practice/reference/ffi.md
@@ -167,7 +167,7 @@ extern "js" fn marked(input : String) -> String = "marked"
 
 #### Requirements
 
-- Must use `"format": "esm"` in `moon.pkg.json` link config
+- Must use `"format": "esm"` in the `moon.pkg` link config
 - Target must be JavaScript backend (`--target js`)
 
 #### Limitations
@@ -185,17 +185,17 @@ let cls = get_some_class()
 
 ## Exporting Functions
 
-Configure in `moon.pkg.json`:
+Configure in `moon.pkg`:
 
-```json
-{
-  "link": {
+```moonbit
+options(
+  link: {
     "js": {
-      "exports": ["add", "fib:fibonacci"],
-      "format": "esm"
-    }
-  }
-}
+      "exports": [ "add", "fib:fibonacci" ],
+      "format": "esm",
+    },
+  },
+)
 ```
 
 ## Callbacks

--- a/lang/moonbit-practice/reference/stdlib.md
+++ b/lang/moonbit-practice/reference/stdlib.md
@@ -9,8 +9,8 @@ The standard library (`moonbitlang/core`) is **automatically available** - no ne
 ## Important Rules
 
 - ❌ **DO NOT** use `moon add moonbitlang/core/*`
-- ❌ **DO NOT** add to `"deps"` in `moon.mod.json`
-- ❌ **DO NOT** add to `"import"` in `moon.pkg.json`
+- ❌ **DO NOT** add it to the `import` block in `moon.mod` (module deps)
+- ❌ **DO NOT** add it to the `import` block in `moon.pkg` (package imports)
 - ✅ **DO** use directly: `@strconv.parse_int()`, `@json.parse()`, etc.
 
 ## Exploring the Standard Library
@@ -319,13 +319,11 @@ moon add moonbitlang/async
 
 ### Important: Import Required for async main/test
 
-To use `async fn main` or `async test`, you **must** import `moonbitlang/async` in your `moon.pkg.json`:
+To use `async fn main` or `async test`, you **must** import `moonbitlang/async` in your `moon.pkg`:
 
-```json
-{
-  "import": [
-    "moonbitlang/async"
-  ]
+```moonbit
+import {
+  "moonbitlang/async",
 }
 ```
 

--- a/lang/moonbit-practice/reference/testing.md
+++ b/lang/moonbit-practice/reference/testing.md
@@ -131,14 +131,12 @@ QuickCheck generates random test inputs automatically.
 
 ### Setup
 
-Add to `moon.pkg.json`:
+Add to `moon.pkg`:
 
-```json
-{
-  "test-import": [
-    "moonbitlang/quickcheck"
-  ]
-}
+```moonbit
+import {
+  "moonbitlang/quickcheck",
+} for "test"
 ```
 
 ### Basic Usage


### PR DESCRIPTION
## Summary

Refresh the `moonbit-practice` skill against recent MoonBit releases (v0.9, v0.9.2, v0.10.0 — the latest shipped 2026-06-08) and the new configuration DSL.

### Language / syntax (v0.9–v0.10.0)
- `trait`/`impl` methods now require the `fn` keyword; added polymorphic trait-method examples.
- `try?` deprecated → `Ok(expr) catch { e => Err(e) }`; error-handling section reworked.
- Removed struct `fn new` → user-defined constructor `fn Type::Type(..)`; added a Structs/Constructors/Methods example.
- Added list comprehensions, template-write `<+`, regex `=~`, `immut/vector` (replaces `immut/array`).
- Snapshot tests: choose `inspect` (primitives/strings) vs `debug_inspect` (containers/custom types) by static type; documented the `Show`-for-containers deprecation and `derive(Debug)` / `derive(Eq)` / `@debug.assert_eq`.

### Configuration DSL (`moon.mod` / `moon.pkg`)
- The `.json` formats are deprecated-pending; reference now leads with the DSL and keeps JSON as legacy.
- Added copy-paste samples `assets/moon.mod` and `assets/moon.pkg`.
- Fixed a stale form in the reference (`import "test" { }` → `import { } for "test"`) and migrated the incidental JSON config mentions in `ffi`/`stdlib`/`testing`.

### Workspaces
- Promote `moon.work` for managing multiple modules in one repo; documented verified `moon work init/use/sync` semantics.

### Verification
- DSL syntax and the `moon.work` manifest format were verified against the local `moon 0.1.20260618` (`moon check` on generated samples, real `moon work init`).
- The skill instructions were hardened with an empirical bias-free-executor eval (3 scenarios incl. a hold-out, all critical-pass at 100%); this surfaced and fixed an internal `inspect`/`debug_inspect` contradiction and missing worked examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)